### PR TITLE
feat(chore): Cargoワークスペース 4クレート構成のセットアップ

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,26 @@
+[workspace]
+resolver = "2"
+members = [
+    "app/core",
+    "app/audio",
+    "app/assets",
+    "app/vampire-survivors",
+]
+
+[workspace.dependencies]
+bevy = "0.17.3"
+bevy_kira_audio = "0.24.0"
+rand = "0.10.0"
+serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.149"
+
+[profile.dev]
+opt-level = 1
+
+[profile.dev.package."*"]
+opt-level = 3
+
+[profile.release]
+opt-level = 3
+lto = true
+codegen-units = 1

--- a/app/assets/Cargo.toml
+++ b/app/assets/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "vs-assets"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+bevy = { workspace = true }

--- a/app/assets/src/lib.rs
+++ b/app/assets/src/lib.rs
@@ -1,0 +1,7 @@
+use bevy::prelude::*;
+
+pub struct GameAssetsPlugin;
+
+impl Plugin for GameAssetsPlugin {
+    fn build(&self, _app: &mut App) {}
+}

--- a/app/audio/Cargo.toml
+++ b/app/audio/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "vs-audio"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+bevy = { workspace = true }
+bevy_kira_audio = { workspace = true }
+vs-core = { path = "../core" }

--- a/app/audio/src/lib.rs
+++ b/app/audio/src/lib.rs
@@ -1,0 +1,10 @@
+use bevy::prelude::*;
+use bevy_kira_audio::AudioPlugin;
+
+pub struct GameAudioPlugin;
+
+impl Plugin for GameAudioPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_plugins(AudioPlugin);
+    }
+}

--- a/app/core/Cargo.toml
+++ b/app/core/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "vs-core"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+bevy = { workspace = true }
+rand = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }

--- a/app/core/src/lib.rs
+++ b/app/core/src/lib.rs
@@ -1,0 +1,7 @@
+use bevy::prelude::*;
+
+pub struct GameCorePlugin;
+
+impl Plugin for GameCorePlugin {
+    fn build(&self, _app: &mut App) {}
+}

--- a/app/vampire-survivors/Cargo.toml
+++ b/app/vampire-survivors/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "vs"
+version = "0.1.0"
+edition = "2024"
+
+[[bin]]
+name = "vs"
+path = "src/main.rs"
+
+[dependencies]
+bevy = { workspace = true }
+vs-core = { path = "../core" }
+vs-audio = { path = "../audio" }
+vs-assets = { path = "../assets" }

--- a/app/vampire-survivors/src/main.rs
+++ b/app/vampire-survivors/src/main.rs
@@ -1,0 +1,24 @@
+use bevy::prelude::*;
+use vs_assets::GameAssetsPlugin;
+use vs_audio::GameAudioPlugin;
+use vs_core::GameCorePlugin;
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins.set(WindowPlugin {
+            primary_window: Some(Window {
+                title: "Vampire Survivors Clone".into(),
+                resolution: (1280, 720).into(),
+                resizable: false,
+                ..default()
+            }),
+            ..default()
+        }))
+        // Load assets first (other plugins may reference them)
+        .add_plugins(GameAssetsPlugin)
+        // Core game logic (ECS, systems, UI)
+        .add_plugins(GameCorePlugin)
+        // Audio (receives core events for BGM/SFX switching)
+        .add_plugins(GameAudioPlugin)
+        .run();
+}


### PR DESCRIPTION
## 概要
4クレート構成のCargoワークスペース（vs-core, vs-audio, vs-assets, vs）を設定し、Bevy 0.17.3でウィンドウが開く基本構造を実装した。

## 変更内容
- ワークスペースルート `Cargo.toml` を作成（resolver=2、共通依存関係定義）
- `app/core/` → `vs-core`：GameCorePluginのスタブ実装
- `app/audio/` → `vs-audio`：bevy_kira_audioのAudioPluginを追加するスタブ実装
- `app/assets/` → `vs-assets`：GameAssetsPluginのスタブ実装
- `app/vampire-survivors/` → `vs`：1280x720ウィンドウを開くmain.rs実装
- Bevy 0.17の`WindowResolution`はu32タプルに変更（0.15のf32から対応）

## テスト
- [x] `cargo build --workspace` 成功確認
- [x] `cargo clippy --workspace -- -D warnings` 警告なし
- [x] `cargo fmt --all` 実行済み

Closes #1