### PR TITLE
feat(core): implement game timer (#9)

### DIFF
--- a/app/core/src/game.rs
+++ b/app/core/src/game.rs
@@ -1,0 +1,82 @@
+//! Game-level systems that operate on the overall run state.
+//!
+//! Systems here update global resources such as [`GameData`] that are not
+//! owned by any single entity category (player, enemy, weapon, etc.).
+
+use bevy::prelude::*;
+
+use crate::resources::GameData;
+
+/// Advances the run timer every frame.
+///
+/// Registered with `run_if(in_state(AppState::Playing))`, so it is
+/// automatically suspended during `LevelUp` and `Paused` states.
+pub fn update_game_timer(time: Res<Time>, mut game_data: ResMut<GameData>) {
+    game_data.elapsed_time += time.delta_secs();
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use bevy::ecs::system::RunSystemOnce as _;
+
+    use super::*;
+
+    fn setup() -> App {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        app.insert_resource(GameData::default());
+        app
+    }
+
+    #[test]
+    fn elapsed_time_increases_by_delta() {
+        let mut app = setup();
+
+        let dt = 1.0 / 60.0_f32;
+        app.world_mut()
+            .resource_mut::<Time>()
+            .advance_by(Duration::from_secs_f32(dt));
+        app.world_mut()
+            .run_system_once(update_game_timer)
+            .expect("update_game_timer should run");
+
+        let elapsed = app.world().resource::<GameData>().elapsed_time;
+        assert!(
+            (elapsed - dt).abs() < 1e-6,
+            "elapsed_time should equal delta (got {elapsed})"
+        );
+    }
+
+    #[test]
+    fn elapsed_time_accumulates_across_frames() {
+        let mut app = setup();
+
+        let dt = 1.0 / 60.0_f32;
+        for _ in 0..3 {
+            app.world_mut()
+                .resource_mut::<Time>()
+                .advance_by(Duration::from_secs_f32(dt));
+            app.world_mut()
+                .run_system_once(update_game_timer)
+                .expect("update_game_timer should run");
+        }
+
+        let elapsed = app.world().resource::<GameData>().elapsed_time;
+        assert!(
+            (elapsed - dt * 3.0).abs() < 1e-5,
+            "elapsed_time should accumulate over 3 frames (got {elapsed})"
+        );
+    }
+
+    #[test]
+    fn elapsed_time_starts_at_zero() {
+        let gd = GameData::default();
+        assert_eq!(gd.elapsed_time, 0.0);
+    }
+}

--- a/app/core/src/lib.rs
+++ b/app/core/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod components;
 pub mod constants;
+pub mod game;
 pub mod player;
 pub mod resources;
 pub mod states;
@@ -7,6 +8,7 @@ pub mod types;
 
 use bevy::prelude::*;
 
+use game::update_game_timer;
 use player::{player_movement, spawn_player};
 use resources::{
     EnemySpawner, GameData, LevelUpChoices, MetaProgress, SelectedCharacter, SpatialGrid,
@@ -47,6 +49,9 @@ impl Plugin for GameCorePlugin {
             // ---------------------------------------------------------------
             // Playing state — per-frame gameplay systems
             // ---------------------------------------------------------------
-            .add_systems(Update, player_movement.run_if(in_state(AppState::Playing)));
+            .add_systems(
+                Update,
+                (player_movement, update_game_timer).run_if(in_state(AppState::Playing)),
+            );
     }
 }


### PR DESCRIPTION
## Summary

- `app/core/src/game.rs` を新規作成し `update_game_timer` システムを実装
- `GameData.elapsed_time` に `Time::delta_secs()` を加算
- `run_if(in_state(AppState::Playing))` により LevelUp・Paused 状態では自動停止

## Acceptance Criteria

- [x] Playing 状態中に `GameData.elapsed_time` が増加する
- [x] LevelUp・Paused 状態ではタイマーが停止する（`run_if` により自動保証）

## Test plan

- [x] `elapsed_time_starts_at_zero` — デフォルト値の確認
- [x] `elapsed_time_increases_by_delta` — 1フレーム分正確に加算されることを確認
- [x] `elapsed_time_accumulates_across_frames` — 複数フレームで累積されることを確認
- [x] `just fmt` / `just clippy` / `just test` — 28テスト全通過

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a game timer that accurately tracks elapsed time during active gameplay. The timer accumulates precise frame-by-frame updates, providing detailed runtime measurements throughout each game session.
  * The timer intelligently pauses when the game transitions to non-playing states, such as during level-ups or pause screens, ensuring only active playtime is recorded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->