### PR TITLE
feat(weapons): weapon data structures for issue #16

### DIFF
--- a/app/core/src/types/weapon.rs
+++ b/app/core/src/types/weapon.rs
@@ -48,6 +48,18 @@ pub struct WeaponState {
     pub evolved: bool,
 }
 
+impl WeaponState {
+    /// Creates a new weapon at level 1 with no active cooldown.
+    pub fn new(weapon_type: WeaponType) -> Self {
+        Self {
+            weapon_type,
+            level: 1,
+            cooldown_timer: 0.0,
+            evolved: false,
+        }
+    }
+}
+
 /// All passive item types. Each has 5 upgrade levels.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum PassiveItemType {
@@ -124,5 +136,36 @@ mod tests {
         let p = PassiveItemType::HollowHeart;
         let _copy = p;
         let _original = p;
+    }
+
+    #[test]
+    fn weapon_state_new_starts_at_level_one() {
+        let state = WeaponState::new(WeaponType::Whip);
+        assert_eq!(state.weapon_type, WeaponType::Whip);
+        assert_eq!(state.level, 1);
+        assert_eq!(state.cooldown_timer, 0.0);
+        assert!(!state.evolved);
+    }
+
+    /// All 8 base weapons must be constructable and start at level 1.
+    #[test]
+    fn weapon_state_new_all_eight_base_weapons() {
+        let base_weapons = [
+            WeaponType::Whip,
+            WeaponType::MagicWand,
+            WeaponType::Knife,
+            WeaponType::Garlic,
+            WeaponType::Bible,
+            WeaponType::ThunderRing,
+            WeaponType::Cross,
+            WeaponType::FireWand,
+        ];
+        assert_eq!(base_weapons.len(), 8, "exactly 8 base weapons required");
+        for weapon_type in base_weapons {
+            let state = WeaponState::new(weapon_type);
+            assert_eq!(state.level, 1);
+            assert_eq!(state.cooldown_timer, 0.0);
+            assert!(!state.evolved);
+        }
     }
 }


### PR DESCRIPTION
## 概要

Issue #16（タスク 4.1: 武器データ構造の定義）の実装。受け入れ基準の3項目はすべて過去のリファクタリング（モジュール分割）で既に満たされていた。本PRでは実装ガイドに記載されていた `WeaponState::new()` コンストラクタの追加と、不足していたユニットテストを補完する。

## 変更内容

- `WeaponState::new(weapon_type)` コンストラクタを追加（レベル1・クールダウン0・未進化で初期化）
- `weapon_state_new_starts_at_level_one` テスト追加
- `weapon_state_new_all_eight_base_weapons` テスト追加（全8武器の構築を検証）

## 受け入れ基準の確認

- [x] `WeaponInventory` コンポーネントが定義されている（`components/player.rs`）
- [x] `WeaponState` 構造体が定義されている（`types/weapon.rs`、weapon_type・level・cooldown_timer フィールド）
- [x] `WeaponType` enum に全8武器が定義されている（Whip, MagicWand, Knife, Garlic, Bible, ThunderRing, Cross, FireWand）

## テスト

- [x] ユニットテスト追加（2件）
- [x] `just check` 実行済み
- [x] `just test` 全テスト通過（71件）

Closes #16

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added weapon initialization with default values (level 1, no cooldown, not evolved state).

* **Tests**
  * Added tests to verify weapon initialization across all weapon types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->