### PR TITLE
feat(collision): add PlayerDamagedEvent, EnemyDiedEvent, rename apply_damage_to_enemies

### DIFF
--- a/app/core/src/events.rs
+++ b/app/core/src/events.rs
@@ -5,7 +5,7 @@
 
 use bevy::prelude::*;
 
-use crate::types::WeaponType;
+use crate::types::{EnemyType, WeaponType};
 
 // ---------------------------------------------------------------------------
 // Weapon events
@@ -32,9 +32,9 @@ pub struct WeaponFiredEvent {
 
 /// Fired when a weapon hits an enemy and should deal damage.
 ///
-/// The [`apply_damage`](crate::systems::damage::apply_damage) system reads
-/// this event each frame and applies the specified amount to the target
-/// enemy's [`Enemy::current_hp`](crate::components::Enemy).
+/// The [`apply_damage_to_enemies`](crate::systems::damage::apply_damage_to_enemies)
+/// system reads this event each frame and applies the specified amount to the
+/// target enemy's [`Enemy::current_hp`](crate::components::Enemy).
 #[derive(Message, Debug, Clone)]
 pub struct DamageEnemyEvent {
     /// The enemy entity to damage.
@@ -43,4 +43,30 @@ pub struct DamageEnemyEvent {
     pub damage: f32,
     /// Which weapon type dealt this damage (for future effect routing).
     pub weapon_type: WeaponType,
+}
+
+/// Fired when an enemy's HP reaches zero and it is removed from the world.
+///
+/// Consumers use this event to spawn XP gems, gold coins, and other rewards
+/// at the enemy's last known position.
+#[derive(Message, Debug, Clone)]
+pub struct EnemyDiedEvent {
+    /// The entity that died (already despawned when consumers read this).
+    pub entity: Entity,
+    /// World-space position at the moment of death, for loot spawning.
+    pub position: Vec2,
+    /// The type of enemy that died, for loot-table lookups.
+    pub enemy_type: EnemyType,
+}
+
+/// Fired when the player takes damage from an enemy or hazard.
+///
+/// Consumers apply the damage to [`PlayerStats::current_hp`](crate::components::PlayerStats),
+/// trigger the invincibility timer, and play hurt effects.
+#[derive(Message, Debug, Clone)]
+pub struct PlayerDamagedEvent {
+    /// The player entity that was hit.
+    pub player: Entity,
+    /// Raw damage amount to subtract from current HP.
+    pub damage: f32,
 }

--- a/app/core/src/lib.rs
+++ b/app/core/src/lib.rs
@@ -8,13 +8,13 @@ pub mod types;
 
 use bevy::prelude::*;
 
-use events::{DamageEnemyEvent, WeaponFiredEvent};
+use events::{DamageEnemyEvent, EnemyDiedEvent, PlayerDamagedEvent, WeaponFiredEvent};
 use resources::{
     EnemySpawner, GameData, LevelUpChoices, MetaProgress, SelectedCharacter, SpatialGrid,
     TreasureSpawner,
 };
 use states::AppState;
-use systems::damage::apply_damage;
+use systems::damage::apply_damage_to_enemies;
 use systems::difficulty::update_difficulty;
 use systems::enemy_ai::move_enemies;
 use systems::enemy_cull::cull_distant_enemies;
@@ -56,6 +56,8 @@ impl Plugin for GameCorePlugin {
             // ---------------------------------------------------------------
             .add_message::<WeaponFiredEvent>()
             .add_message::<DamageEnemyEvent>()
+            .add_message::<EnemyDiedEvent>()
+            .add_message::<PlayerDamagedEvent>()
             // ---------------------------------------------------------------
             // Playing state — player lifecycle
             // ---------------------------------------------------------------
@@ -75,7 +77,9 @@ impl Plugin for GameCorePlugin {
                     fire_whip
                         .after(tick_weapon_cooldowns)
                         .after(update_spatial_grid),
-                    apply_damage.after(fire_whip).after(fire_magic_wand),
+                    apply_damage_to_enemies
+                        .after(fire_whip)
+                        .after(fire_magic_wand),
                     despawn_whip_effects,
                     move_projectiles,
                     despawn_expired_projectiles,

--- a/app/core/src/systems/damage.rs
+++ b/app/core/src/systems/damage.rs
@@ -1,13 +1,16 @@
 //! Damage application system.
 //!
-//! [`apply_damage`] reads every [`DamageEnemyEvent`] queued this frame and
-//! reduces the target enemy's HP via [`Enemy::take_damage`].  Enemies whose HP
-//! reaches zero are despawned immediately.  Reward spawning (XP gems, gold
-//! coins) will be added in a later phase.
+//! [`apply_damage_to_enemies`] reads every [`DamageEnemyEvent`] queued this
+//! frame and reduces the target enemy's HP via [`Enemy::take_damage`].
+//! Enemies whose HP reaches zero are despawned and an [`EnemyDiedEvent`] is
+//! emitted so downstream systems (XP gems, gold coins) can react.
 
 use bevy::prelude::*;
 
-use crate::{components::Enemy, events::DamageEnemyEvent};
+use crate::{
+    components::Enemy,
+    events::{DamageEnemyEvent, EnemyDiedEvent},
+};
 
 // ---------------------------------------------------------------------------
 // System
@@ -17,19 +20,29 @@ use crate::{components::Enemy, events::DamageEnemyEvent};
 ///
 /// - If the target entity no longer exists (already despawned) the event is
 ///   silently skipped.
-/// - Enemies reduced to zero HP are despawned immediately.
-pub fn apply_damage(
-    mut events: MessageReader<DamageEnemyEvent>,
-    mut enemy_q: Query<&mut Enemy>,
+/// - Enemies reduced to zero HP are despawned and an [`EnemyDiedEvent`] is
+///   emitted carrying the entity, world position, and enemy type for loot
+///   spawning.
+pub fn apply_damage_to_enemies(
+    mut damage_events: MessageReader<DamageEnemyEvent>,
+    mut died_events: MessageWriter<EnemyDiedEvent>,
+    mut enemy_q: Query<(&mut Enemy, &Transform)>,
     mut commands: Commands,
 ) {
-    for event in events.read() {
-        let Ok(mut enemy) = enemy_q.get_mut(event.entity) else {
+    for event in damage_events.read() {
+        let Ok((mut enemy, transform)) = enemy_q.get_mut(event.entity) else {
             continue;
         };
         enemy.take_damage(event.damage);
         if enemy.is_dead() {
+            let position = transform.translation.truncate();
+            let enemy_type = enemy.enemy_type;
             commands.entity(event.entity).despawn();
+            died_events.write(EnemyDiedEvent {
+                entity: event.entity,
+                position,
+                enemy_type,
+            });
         }
     }
 }
@@ -45,7 +58,7 @@ mod tests {
     use super::*;
     use crate::{
         components::Enemy,
-        events::DamageEnemyEvent,
+        events::{DamageEnemyEvent, EnemyDiedEvent},
         types::{EnemyType, WeaponType},
     };
 
@@ -53,12 +66,16 @@ mod tests {
         let mut app = App::new();
         app.add_plugins(MinimalPlugins);
         app.add_message::<DamageEnemyEvent>();
+        app.add_message::<EnemyDiedEvent>();
         app
     }
 
     fn spawn_enemy(app: &mut App) -> Entity {
         app.world_mut()
-            .spawn(Enemy::from_type(EnemyType::Bat, 1.0))
+            .spawn((
+                Enemy::from_type(EnemyType::Bat, 1.0),
+                Transform::from_xyz(10.0, 20.0, 0.0),
+            ))
             .id()
     }
 
@@ -72,8 +89,14 @@ mod tests {
 
     fn run_apply(app: &mut App) {
         app.world_mut()
-            .run_system_once(apply_damage)
-            .expect("apply_damage should run");
+            .run_system_once(apply_damage_to_enemies)
+            .expect("apply_damage_to_enemies should run");
+    }
+
+    fn died_events(app: &App) -> Vec<EnemyDiedEvent> {
+        let messages = app.world().resource::<Messages<EnemyDiedEvent>>();
+        let mut cursor = messages.get_cursor();
+        cursor.read(messages).cloned().collect()
     }
 
     /// Damage event reduces enemy HP by the specified amount.
@@ -103,6 +126,43 @@ mod tests {
             app.world().get_entity(entity).is_err(),
             "dead enemy should be despawned"
         );
+    }
+
+    /// Lethal damage emits an EnemyDiedEvent with correct position and type.
+    #[test]
+    fn lethal_damage_emits_enemy_died_event() {
+        let mut app = build_app();
+        let entity = spawn_enemy(&mut app); // spawned at (10, 20)
+
+        send_damage(&mut app, entity, 9999.0);
+        run_apply(&mut app);
+
+        let events = died_events(&app);
+        assert_eq!(
+            events.len(),
+            1,
+            "exactly one EnemyDiedEvent should be emitted"
+        );
+        assert_eq!(events[0].entity, entity);
+        assert_eq!(events[0].position, Vec2::new(10.0, 20.0));
+        assert_eq!(events[0].enemy_type, EnemyType::Bat);
+    }
+
+    /// Non-lethal damage does not emit an EnemyDiedEvent.
+    #[test]
+    fn non_lethal_damage_no_died_event() {
+        let mut app = build_app();
+        let entity = spawn_enemy(&mut app);
+
+        send_damage(&mut app, entity, 1.0);
+        run_apply(&mut app);
+
+        assert!(
+            died_events(&app).is_empty(),
+            "non-lethal damage should not emit EnemyDiedEvent"
+        );
+        // Entity still alive
+        assert!(app.world().get_entity(entity).is_ok());
     }
 
     /// Event targeting a non-existent entity is silently ignored.


### PR DESCRIPTION
## 概要

issue #24 の受け入れ基準を満たすため、以下を実装します。

- closes #24

## 変更内容

### `events.rs`
- `EnemyDiedEvent` を追加 — `entity`, `position: Vec2`, `enemy_type: EnemyType`
  - `apply_damage_to_enemies` が敵を despawn する直前に位置を記録して送信
  - 後続フェーズの XP ジェム・ゴールドコインスポーンで利用
- `PlayerDamagedEvent` を追加 — `player: Entity`, `damage: f32`
  - 敵との接触判定システム（後続フェーズ）が送信する

### `systems/damage.rs`
- `apply_damage` → `apply_damage_to_enemies` にリネーム
- `EnemyDiedEvent` 送信: 死亡した敵の位置・タイプをイベントに含める

### `lib.rs`
- `EnemyDiedEvent` / `PlayerDamagedEvent` を `.add_message` で登録
- システム参照を `apply_damage_to_enemies` に更新

## テスト計画

- [x] `lethal_damage_emits_enemy_died_event` — 致死ダメージで `EnemyDiedEvent` が位置・タイプ付きで送信される
- [x] `non_lethal_damage_no_died_event` — 非致死ダメージでは `EnemyDiedEvent` が送信されない
- [x] 既存テスト全 130 件パス、`just clippy` 警告なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented enemy death detection system that captures entity position and type information.
  * Added player damage event tracking system.

* **Refactor**
  * Enhanced damage system architecture to integrate new event-driven approach, improving game mechanics handling and system reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->