### PR TITLE
feat(collision): implement projectile vs enemy collision detection

### DIFF
--- a/app/core/src/lib.rs
+++ b/app/core/src/lib.rs
@@ -22,6 +22,7 @@ use systems::enemy_spawn::spawn_enemies;
 use systems::game_timer::update_game_timer;
 use systems::player::{player_movement, spawn_player};
 use systems::projectile::{despawn_expired_projectiles, move_projectiles};
+use systems::projectile_collision::projectile_enemy_collision;
 use systems::spatial::update_spatial_grid;
 use systems::weapon_cooldown::tick_weapon_cooldowns;
 use systems::weapon_magic_wand::fire_magic_wand;
@@ -77,9 +78,13 @@ impl Plugin for GameCorePlugin {
                     fire_whip
                         .after(tick_weapon_cooldowns)
                         .after(update_spatial_grid),
+                    projectile_enemy_collision
+                        .after(update_spatial_grid)
+                        .after(move_projectiles),
                     apply_damage_to_enemies
                         .after(fire_whip)
-                        .after(fire_magic_wand),
+                        .after(fire_magic_wand)
+                        .after(projectile_enemy_collision),
                     despawn_whip_effects,
                     move_projectiles,
                     despawn_expired_projectiles,

--- a/app/core/src/systems/mod.rs
+++ b/app/core/src/systems/mod.rs
@@ -12,6 +12,7 @@ pub mod enemy_spawn;
 pub mod game_timer;
 pub mod player;
 pub mod projectile;
+pub mod projectile_collision;
 pub mod spatial;
 pub mod weapon_cooldown;
 pub mod weapon_magic_wand;

--- a/app/core/src/systems/projectile_collision.rs
+++ b/app/core/src/systems/projectile_collision.rs
@@ -1,0 +1,327 @@
+//! Projectile vs enemy collision detection.
+//!
+//! [`projectile_enemy_collision`] runs once per frame after the spatial grid
+//! has been updated and projectiles have moved.  For each live projectile it
+//! queries the [`SpatialGrid`] for candidate enemies, performs exact circle
+//! overlap checks, and — on a hit — emits a [`DamageEnemyEvent`].
+//!
+//! # Piercing behaviour
+//!
+//! A projectile's `piercing` counter controls how many *additional* enemies it
+//! penetrates after the first hit:
+//!
+//! - `piercing == 0` → single-hit; the projectile is despawned on the first hit.
+//! - `piercing >= 1` → multi-hit; each hit decrements `piercing` by 1 and
+//!   records the struck enemy in `hit_enemies` to prevent a double-hit on the
+//!   same target.  The projectile is despawned only when `piercing` reaches 0
+//!   and the next enemy is hit.
+
+use bevy::prelude::*;
+
+use crate::{
+    components::{CircleCollider, Enemy, Projectile},
+    events::DamageEnemyEvent,
+    resources::SpatialGrid,
+    systems::collision::check_circle_collision,
+};
+
+// ---------------------------------------------------------------------------
+// Fallback constant
+// ---------------------------------------------------------------------------
+
+/// Conservative upper bound on any enemy's collider radius (pixels).
+///
+/// Used to widen the spatial-grid query so that large enemies whose centres
+/// lie just outside the projectile's radius are still returned as candidates.
+const MAX_ENEMY_COLLIDER_RADIUS: f32 = 32.0;
+
+// ---------------------------------------------------------------------------
+// System
+// ---------------------------------------------------------------------------
+
+/// Detects projectile–enemy overlaps and emits [`DamageEnemyEvent`] on hits.
+///
+/// For each projectile the system:
+/// 1. Queries the [`SpatialGrid`] with `proj_radius + MAX_ENEMY_COLLIDER_RADIUS`
+///    to obtain candidate entities (may include false positives).
+/// 2. Skips candidates already present in `projectile.hit_enemies`.
+/// 3. Performs an exact [`check_circle_collision`] check.
+/// 4. On a hit, writes a [`DamageEnemyEvent`] and either:
+///    - despawns the projectile (`piercing == 0`), or
+///    - records the enemy in `hit_enemies` and decrements `piercing`.
+pub fn projectile_enemy_collision(
+    mut projectile_q: Query<(Entity, &mut Projectile, &Transform, &CircleCollider)>,
+    enemy_q: Query<(&Transform, &CircleCollider), With<Enemy>>,
+    spatial_grid: Res<SpatialGrid>,
+    mut damage_events: MessageWriter<DamageEnemyEvent>,
+    mut commands: Commands,
+) {
+    for (proj_entity, mut projectile, proj_tf, proj_collider) in projectile_q.iter_mut() {
+        let proj_pos = proj_tf.translation.truncate();
+        let query_radius = proj_collider.radius + MAX_ENEMY_COLLIDER_RADIUS;
+
+        let candidates = spatial_grid.get_nearby(proj_pos, query_radius);
+
+        let mut should_despawn = false;
+
+        for candidate in candidates {
+            if projectile.hit_enemies.contains(&candidate) {
+                continue;
+            }
+
+            let Ok((enemy_tf, enemy_collider)) = enemy_q.get(candidate) else {
+                continue;
+            };
+
+            let enemy_pos = enemy_tf.translation.truncate();
+            if !check_circle_collision(
+                proj_pos,
+                proj_collider.radius,
+                enemy_pos,
+                enemy_collider.radius,
+            ) {
+                continue;
+            }
+
+            // Hit confirmed — emit damage event.
+            damage_events.write(DamageEnemyEvent {
+                entity: candidate,
+                damage: projectile.damage,
+                weapon_type: projectile.weapon_type,
+            });
+
+            if projectile.piercing == 0 {
+                should_despawn = true;
+                break;
+            } else {
+                projectile.hit_enemies.push(candidate);
+                projectile.piercing -= 1;
+            }
+        }
+
+        if should_despawn {
+            commands.entity(proj_entity).despawn();
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use bevy::ecs::system::RunSystemOnce as _;
+
+    use super::*;
+    use crate::{
+        components::{CircleCollider, Enemy, Projectile, ProjectileVelocity},
+        events::DamageEnemyEvent,
+        resources::SpatialGrid,
+        types::{EnemyType, WeaponType},
+    };
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    fn build_app() -> App {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        app.add_message::<DamageEnemyEvent>();
+        app.insert_resource(SpatialGrid::default());
+        app
+    }
+
+    fn spawn_projectile(app: &mut App, pos: Vec2, radius: f32, piercing: u32) -> Entity {
+        app.world_mut()
+            .spawn((
+                Projectile {
+                    damage: 10.0,
+                    piercing,
+                    hit_enemies: Vec::new(),
+                    lifetime: 5.0,
+                    weapon_type: WeaponType::MagicWand,
+                },
+                ProjectileVelocity(Vec2::ZERO),
+                Transform::from_xyz(pos.x, pos.y, 5.0),
+                CircleCollider { radius },
+            ))
+            .id()
+    }
+
+    fn spawn_enemy(app: &mut App, pos: Vec2, radius: f32) -> Entity {
+        app.world_mut()
+            .spawn((
+                Enemy::from_type(EnemyType::Bat, 1.0),
+                Transform::from_xyz(pos.x, pos.y, 1.0),
+                CircleCollider { radius },
+            ))
+            .id()
+    }
+
+    /// Populate the SpatialGrid with all current enemy positions.
+    fn update_grid(app: &mut App) {
+        use crate::systems::spatial::update_spatial_grid;
+        app.world_mut()
+            .run_system_once(update_spatial_grid)
+            .expect("update_spatial_grid should run");
+    }
+
+    fn run_collision(app: &mut App) {
+        app.world_mut()
+            .run_system_once(projectile_enemy_collision)
+            .expect("projectile_enemy_collision should run");
+    }
+
+    fn damage_events(app: &App) -> Vec<DamageEnemyEvent> {
+        let messages = app.world().resource::<Messages<DamageEnemyEvent>>();
+        let mut cursor = messages.get_cursor();
+        cursor.read(messages).cloned().collect()
+    }
+
+    // -----------------------------------------------------------------------
+    // Tests
+    // -----------------------------------------------------------------------
+
+    /// A projectile overlapping an enemy emits a DamageEnemyEvent.
+    #[test]
+    fn hit_emits_damage_event() {
+        let mut app = build_app();
+        let enemy = spawn_enemy(&mut app, Vec2::new(5.0, 0.0), 10.0);
+        spawn_projectile(&mut app, Vec2::ZERO, 8.0, 0);
+
+        update_grid(&mut app);
+        run_collision(&mut app);
+
+        let events = damage_events(&app);
+        assert_eq!(events.len(), 1, "expected one damage event on hit");
+        assert_eq!(events[0].entity, enemy);
+        assert_eq!(events[0].damage, 10.0);
+    }
+
+    /// A non-piercing projectile (piercing == 0) is despawned after the first hit.
+    #[test]
+    fn non_piercing_projectile_despawns_on_hit() {
+        let mut app = build_app();
+        spawn_enemy(&mut app, Vec2::new(5.0, 0.0), 10.0);
+        let proj = spawn_projectile(&mut app, Vec2::ZERO, 8.0, 0);
+
+        update_grid(&mut app);
+        run_collision(&mut app);
+        app.world_mut().flush();
+
+        assert!(
+            app.world().get_entity(proj).is_err(),
+            "non-piercing projectile should be despawned after hit"
+        );
+    }
+
+    /// A piercing projectile (piercing == 1) survives the first hit and is
+    /// despawned only after it hits the second enemy.
+    #[test]
+    fn piercing_projectile_survives_first_hit() {
+        let mut app = build_app();
+        spawn_enemy(&mut app, Vec2::new(5.0, 0.0), 10.0);
+        let proj = spawn_projectile(&mut app, Vec2::ZERO, 8.0, 1);
+
+        update_grid(&mut app);
+        run_collision(&mut app);
+        app.world_mut().flush();
+
+        assert!(
+            app.world().get_entity(proj).is_ok(),
+            "piercing projectile should survive its first hit"
+        );
+        // Piercing counter decremented.
+        let p = app.world().get::<Projectile>(proj).unwrap();
+        assert_eq!(p.piercing, 0);
+        assert_eq!(p.hit_enemies.len(), 1);
+    }
+
+    /// A piercing projectile is despawned after exhausting its pierce count.
+    #[test]
+    fn piercing_projectile_despawns_after_exhausting_pierce() {
+        let mut app = build_app();
+        // Two enemies at the same position — both overlap the projectile.
+        spawn_enemy(&mut app, Vec2::new(5.0, 0.0), 10.0);
+        spawn_enemy(&mut app, Vec2::new(5.0, 0.0), 10.0);
+        let proj = spawn_projectile(&mut app, Vec2::ZERO, 8.0, 1);
+
+        update_grid(&mut app);
+        run_collision(&mut app);
+        app.world_mut().flush();
+
+        assert!(
+            app.world().get_entity(proj).is_err(),
+            "projectile with piercing=1 should be despawned after hitting two enemies"
+        );
+        let events = damage_events(&app);
+        assert_eq!(events.len(), 2, "both enemies should have been hit");
+    }
+
+    /// An already-hit enemy is not damaged again by the same projectile.
+    #[test]
+    fn already_hit_enemy_is_not_hit_again() {
+        let mut app = build_app();
+        let enemy = spawn_enemy(&mut app, Vec2::new(5.0, 0.0), 10.0);
+        let proj = spawn_projectile(&mut app, Vec2::ZERO, 8.0, 2);
+
+        // Pre-populate hit_enemies so the enemy is already recorded.
+        app.world_mut()
+            .get_mut::<Projectile>(proj)
+            .unwrap()
+            .hit_enemies
+            .push(enemy);
+
+        update_grid(&mut app);
+        run_collision(&mut app);
+
+        let events = damage_events(&app);
+        assert!(
+            events.is_empty(),
+            "enemy already in hit_enemies must not be hit again"
+        );
+    }
+
+    /// A projectile that does not overlap any enemy emits no events.
+    #[test]
+    fn miss_emits_no_event() {
+        let mut app = build_app();
+        // Enemy far away — no collision.
+        spawn_enemy(&mut app, Vec2::new(500.0, 0.0), 10.0);
+        spawn_projectile(&mut app, Vec2::ZERO, 8.0, 0);
+
+        update_grid(&mut app);
+        run_collision(&mut app);
+
+        assert!(
+            damage_events(&app).is_empty(),
+            "miss should produce no events"
+        );
+    }
+
+    /// No enemies in the world — system completes without panic.
+    #[test]
+    fn no_enemies_no_events() {
+        let mut app = build_app();
+        spawn_projectile(&mut app, Vec2::ZERO, 8.0, 0);
+
+        update_grid(&mut app);
+        run_collision(&mut app);
+
+        assert!(damage_events(&app).is_empty());
+    }
+
+    /// No projectiles in the world — system completes without panic.
+    #[test]
+    fn no_projectiles_no_events() {
+        let mut app = build_app();
+        spawn_enemy(&mut app, Vec2::ZERO, 10.0);
+
+        update_grid(&mut app);
+        run_collision(&mut app);
+
+        assert!(damage_events(&app).is_empty());
+    }
+}


### PR DESCRIPTION
## 概要

弾と敵の衝突判定システム `projectile_enemy_collision` を実装します。

- closes #25

## 実装詳細

### `systems/projectile_collision.rs` (新規)

**アルゴリズム:**
1. 各プロジェクタイルについて `SpatialGrid::get_nearby(proj_pos, proj_radius + MAX_ENEMY_COLLIDER_RADIUS)` で候補敵を取得
2. `hit_enemies` にすでに記録された敵はスキップ
3. `check_circle_collision` で正確な円形衝突判定
4. ヒット時:
   - `piercing == 0` → `DamageEnemyEvent` 送信 + プロジェクタイル despawn
   - `piercing >= 1` → `DamageEnemyEvent` 送信 + `hit_enemies` に追記 + `piercing` 減算

### `lib.rs` でのシステム順序

```
update_spatial_grid.after(player_movement)
move_projectiles
projectile_enemy_collision.after(update_spatial_grid).after(move_projectiles)
apply_damage_to_enemies.after(...).after(projectile_enemy_collision)
```

## テスト計画

- [x] `hit_emits_damage_event` — ヒット時に DamageEnemyEvent が送信される
- [x] `non_piercing_projectile_despawns_on_hit` — piercing=0 の弾はヒットで消える
- [x] `piercing_projectile_survives_first_hit` — piercing=1 の弾は1体目のヒット後も生存
- [x] `piercing_projectile_despawns_after_exhausting_pierce` — 2体ヒットで消える
- [x] `already_hit_enemy_is_not_hit_again` — 同じ敵への連続ヒットを防止
- [x] `miss_emits_no_event` — 範囲外の敵にはイベントなし
- [x] `no_enemies_no_events` — 敵なしでもパニックなし
- [x] `no_projectiles_no_events` — 弾なしでもパニックなし
- [x] 全 138 テストパス、`just clippy` 警告なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Projectile-enemy collision detection now active in gameplay, enabling projectiles to detect and interact with enemies each frame
  * Added piercing support allowing projectiles to pass through multiple enemies

* **Tests**
  * Comprehensive test suite added covering collision detection, piercing behavior, and multi-hit mechanics

<!-- end of auto-generated comment: release notes by coderabbit.ai -->