### PR TITLE
feat(weapons): implement WeaponState::base_damage and base_count

### DIFF
--- a/app/core/src/types/weapon.rs
+++ b/app/core/src/types/weapon.rs
@@ -1,5 +1,37 @@
 use serde::{Deserialize, Serialize};
 
+// ---------------------------------------------------------------------------
+// Fallback constants for base_damage() and base_count()
+//
+// These mirror the values in assets/config/weapons/*.ron and serve as
+// fallbacks when the RON assets have not yet finished loading.
+// ---------------------------------------------------------------------------
+
+// --- Whip / MagicWand (linear: base + per_level × (level − 1)) ---
+const DEFAULT_WHIP_BASE_DAMAGE: f32 = 20.0;
+const DEFAULT_WHIP_DAMAGE_PER_LEVEL: f32 = 10.0;
+const DEFAULT_MAGIC_WAND_BASE_DAMAGE: f32 = 20.0;
+const DEFAULT_MAGIC_WAND_DAMAGE_PER_LEVEL: f32 = 10.0;
+
+// --- Knife (step formula: base + step × floor((level−1) / 2)) ---
+const DEFAULT_KNIFE_BASE_DAMAGE: f32 = 15.0;
+const DEFAULT_KNIFE_DAMAGE_PER_TWO_LEVELS: f32 = 5.0;
+const DEFAULT_KNIFE_COUNT_BY_LEVEL: [u32; 8] = [1, 1, 2, 2, 3, 3, 4, 5];
+
+// --- Fixed per-level damage tables (Lv1..Lv8) ---
+const DEFAULT_GARLIC_DAMAGE_BY_LEVEL: [f32; 8] = [5.0, 5.0, 8.0, 8.0, 10.0, 12.0, 15.0, 20.0];
+const DEFAULT_BIBLE_DAMAGE_BY_LEVEL: [f32; 8] = [20.0, 25.0, 30.0, 35.0, 40.0, 50.0, 60.0, 80.0];
+const DEFAULT_THUNDER_RING_DAMAGE_BY_LEVEL: [f32; 8] =
+    [40.0, 50.0, 60.0, 60.0, 70.0, 80.0, 90.0, 100.0];
+const DEFAULT_CROSS_DAMAGE_BY_LEVEL: [f32; 8] = [50.0, 60.0, 70.0, 80.0, 90.0, 110.0, 130.0, 160.0];
+const DEFAULT_FIRE_WAND_DAMAGE_BY_LEVEL: [f32; 8] =
+    [80.0, 100.0, 120.0, 150.0, 180.0, 220.0, 270.0, 330.0];
+
+// --- Fixed per-level count tables (Lv1..Lv8) ---
+const DEFAULT_BIBLE_COUNT_BY_LEVEL: [u32; 8] = [1, 1, 2, 2, 3, 3, 3, 3];
+const DEFAULT_THUNDER_RING_COUNT_BY_LEVEL: [u32; 8] = [1, 1, 2, 2, 3, 3, 3, 4];
+const DEFAULT_CROSS_COUNT_BY_LEVEL: [u32; 8] = [1, 1, 1, 1, 2, 2, 2, 2];
+
 /// All weapon types, including evolved forms.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum WeaponType {
@@ -150,18 +182,25 @@ impl WeaponState {
     pub fn base_damage(&self) -> f32 {
         let level = self.level.clamp(1, 8) as usize;
         match self.weapon_type {
-            // Linear scaling: 20 + 10 per level above 1.
-            WeaponType::Whip | WeaponType::MagicWand => 20.0 + 10.0 * (level as f32 - 1.0),
-            // Steps every two levels: 15 + 5 * floor((level-1) / 2).
-            WeaponType::Knife => 15.0 + 5.0 * ((level - 1) / 2) as f32,
-            // Fixed tables matching the RON config files.
-            WeaponType::Garlic => [5.0, 5.0, 8.0, 8.0, 10.0, 12.0, 15.0, 20.0][level - 1],
-            WeaponType::Bible => [20.0, 25.0, 30.0, 35.0, 40.0, 50.0, 60.0, 80.0][level - 1],
-            WeaponType::ThunderRing => [40.0, 50.0, 60.0, 60.0, 70.0, 80.0, 90.0, 100.0][level - 1],
-            WeaponType::Cross => [50.0, 60.0, 70.0, 80.0, 90.0, 110.0, 130.0, 160.0][level - 1],
-            WeaponType::FireWand => {
-                [80.0, 100.0, 120.0, 150.0, 180.0, 220.0, 270.0, 330.0][level - 1]
+            // Linear scaling: base + per_level × (level − 1).
+            WeaponType::Whip => {
+                DEFAULT_WHIP_BASE_DAMAGE + DEFAULT_WHIP_DAMAGE_PER_LEVEL * (level as f32 - 1.0)
             }
+            WeaponType::MagicWand => {
+                DEFAULT_MAGIC_WAND_BASE_DAMAGE
+                    + DEFAULT_MAGIC_WAND_DAMAGE_PER_LEVEL * (level as f32 - 1.0)
+            }
+            // Step formula: base + step × floor((level−1) / 2).
+            WeaponType::Knife => {
+                DEFAULT_KNIFE_BASE_DAMAGE
+                    + DEFAULT_KNIFE_DAMAGE_PER_TWO_LEVELS * ((level - 1) / 2) as f32
+            }
+            // Fixed tables — values mirror the RON config files.
+            WeaponType::Garlic => DEFAULT_GARLIC_DAMAGE_BY_LEVEL[level - 1],
+            WeaponType::Bible => DEFAULT_BIBLE_DAMAGE_BY_LEVEL[level - 1],
+            WeaponType::ThunderRing => DEFAULT_THUNDER_RING_DAMAGE_BY_LEVEL[level - 1],
+            WeaponType::Cross => DEFAULT_CROSS_DAMAGE_BY_LEVEL[level - 1],
+            WeaponType::FireWand => DEFAULT_FIRE_WAND_DAMAGE_BY_LEVEL[level - 1],
             // Evolved weapons are fixed at their max-level power.
             WeaponType::BloodyTear => 90.0,
             WeaponType::HolyWand => 90.0,
@@ -196,14 +235,16 @@ impl WeaponState {
             | WeaponType::MagicWand
             | WeaponType::Garlic
             | WeaponType::FireWand => 1,
-            // Per-level count tables matching the RON config files.
-            WeaponType::Knife => [1, 1, 2, 2, 3, 3, 4, 5][level - 1],
-            WeaponType::Bible => [1, 1, 2, 2, 3, 3, 3, 3][level - 1],
-            WeaponType::ThunderRing => [1, 1, 2, 2, 3, 3, 3, 4][level - 1],
-            WeaponType::Cross => [1, 1, 1, 1, 2, 2, 2, 2][level - 1],
+            // Per-level count tables — values mirror the RON config files.
+            WeaponType::Knife => DEFAULT_KNIFE_COUNT_BY_LEVEL[level - 1],
+            WeaponType::Bible => DEFAULT_BIBLE_COUNT_BY_LEVEL[level - 1],
+            WeaponType::ThunderRing => DEFAULT_THUNDER_RING_COUNT_BY_LEVEL[level - 1],
+            WeaponType::Cross => DEFAULT_CROSS_COUNT_BY_LEVEL[level - 1],
             // Evolved weapons — fixed at max-level count of their base.
             WeaponType::BloodyTear | WeaponType::HolyWand | WeaponType::SoulEater => 1,
-            WeaponType::ThousandEdge => 5,
+            // ThousandEdge: weapon_knife.rs fires count * 2 for the evolved form,
+            // so the effective count at Lv8 (base count 5 × 2) is 10.
+            WeaponType::ThousandEdge => 10,
             WeaponType::UnholyVespers => 3,
             WeaponType::LightningRing => 4,
         }
@@ -348,87 +389,144 @@ mod tests {
     // base_damage tests
     // -----------------------------------------------------------------------
 
-    /// Whip and MagicWand scale linearly: 20 + 10*(level-1).
-    #[test]
-    fn base_damage_whip_magic_wand_linear() {
-        for weapon_type in [WeaponType::Whip, WeaponType::MagicWand] {
-            let mut state = WeaponState::new(weapon_type);
-            assert_eq!(state.base_damage(), 20.0, "{weapon_type:?} lv1");
-            state.level = 4;
-            assert_eq!(state.base_damage(), 50.0, "{weapon_type:?} lv4");
-            state.level = 8;
-            assert_eq!(state.base_damage(), 90.0, "{weapon_type:?} lv8");
-        }
-    }
+    // The parity tests below load and deserialize the live RON config files at
+    // compile time via `include_str!`, so any drift between the DEFAULT_*
+    // fallback constants and `assets/config/weapons/*.ron` is caught at
+    // compile/test time rather than at runtime.
 
-    /// Knife damage steps every two levels: 15 + 5*floor((level-1)/2).
+    /// Whip base_damage() matches the RON config formula for all 8 levels.
     #[test]
-    fn base_damage_knife_steps_every_two_levels() {
-        let expected = [15.0, 15.0, 20.0, 20.0, 25.0, 25.0, 30.0, 30.0];
-        let mut state = WeaponState::new(WeaponType::Knife);
-        for (i, &expected_dmg) in expected.iter().enumerate() {
-            state.level = (i + 1) as u8;
+    fn base_damage_whip_matches_ron_config() {
+        use crate::config::weapon::WhipConfig;
+        let cfg: WhipConfig = ron::de::from_str(include_str!(
+            "../../../vampire-survivors/assets/config/weapons/whip.ron"
+        ))
+        .expect("whip.ron should parse");
+        let mut state = WeaponState::new(WeaponType::Whip);
+        for level in 1..=8u8 {
+            state.level = level;
+            let expected = cfg.base_damage + cfg.damage_per_level * (level as f32 - 1.0);
             assert_eq!(
                 state.base_damage(),
-                expected_dmg,
-                "Knife lv{} expected {expected_dmg}",
-                i + 1
+                expected,
+                "Whip lv{level}: expected {expected}"
             );
         }
     }
 
-    /// Garlic damage matches the RON config table.
+    /// MagicWand base_damage() matches the RON config formula for all 8 levels.
     #[test]
-    fn base_damage_garlic_matches_table() {
-        let expected = [5.0, 5.0, 8.0, 8.0, 10.0, 12.0, 15.0, 20.0];
+    fn base_damage_magic_wand_matches_ron_config() {
+        use crate::config::weapon::MagicWandConfig;
+        let cfg: MagicWandConfig = ron::de::from_str(include_str!(
+            "../../../vampire-survivors/assets/config/weapons/magic_wand.ron"
+        ))
+        .expect("magic_wand.ron should parse");
+        let mut state = WeaponState::new(WeaponType::MagicWand);
+        for level in 1..=8u8 {
+            state.level = level;
+            let expected = cfg.base_damage + cfg.damage_per_level * (level as f32 - 1.0);
+            assert_eq!(
+                state.base_damage(),
+                expected,
+                "MagicWand lv{level}: expected {expected}"
+            );
+        }
+    }
+
+    /// Knife base_damage() matches the RON config step formula for all 8 levels.
+    #[test]
+    fn base_damage_knife_matches_ron_config() {
+        use crate::config::weapon::KnifeConfig;
+        let cfg: KnifeConfig = ron::de::from_str(include_str!(
+            "../../../vampire-survivors/assets/config/weapons/knife.ron"
+        ))
+        .expect("knife.ron should parse");
+        let mut state = WeaponState::new(WeaponType::Knife);
+        for level in 1..=8u8 {
+            state.level = level;
+            let step = ((level as usize - 1) / 2) as f32;
+            let expected = cfg.base_damage + cfg.damage_per_two_levels * step;
+            assert_eq!(
+                state.base_damage(),
+                expected,
+                "Knife lv{level}: expected {expected}"
+            );
+        }
+    }
+
+    /// Garlic base_damage() matches the per-level table in garlic.ron.
+    #[test]
+    fn base_damage_garlic_matches_ron_config() {
+        use crate::config::weapon::GarlicConfig;
+        let cfg: GarlicConfig = ron::de::from_str(include_str!(
+            "../../../vampire-survivors/assets/config/weapons/garlic.ron"
+        ))
+        .expect("garlic.ron should parse");
         let mut state = WeaponState::new(WeaponType::Garlic);
-        for (i, &expected_dmg) in expected.iter().enumerate() {
+        for (i, &expected) in cfg.damage_by_level.iter().enumerate() {
             state.level = (i + 1) as u8;
-            assert_eq!(state.base_damage(), expected_dmg, "Garlic lv{}", i + 1);
+            assert_eq!(state.base_damage(), expected, "Garlic lv{}", i + 1);
         }
     }
 
-    /// Bible damage matches the RON config table.
+    /// Bible base_damage() matches the per-level table in bible.ron.
     #[test]
-    fn base_damage_bible_matches_table() {
-        let expected = [20.0, 25.0, 30.0, 35.0, 40.0, 50.0, 60.0, 80.0];
+    fn base_damage_bible_matches_ron_config() {
+        use crate::config::weapon::BibleConfig;
+        let cfg: BibleConfig = ron::de::from_str(include_str!(
+            "../../../vampire-survivors/assets/config/weapons/bible.ron"
+        ))
+        .expect("bible.ron should parse");
         let mut state = WeaponState::new(WeaponType::Bible);
-        for (i, &expected_dmg) in expected.iter().enumerate() {
+        for (i, &expected) in cfg.damage_by_level.iter().enumerate() {
             state.level = (i + 1) as u8;
-            assert_eq!(state.base_damage(), expected_dmg, "Bible lv{}", i + 1);
+            assert_eq!(state.base_damage(), expected, "Bible lv{}", i + 1);
         }
     }
 
-    /// ThunderRing damage matches the RON config table.
+    /// ThunderRing base_damage() matches the per-level table in thunder_ring.ron.
     #[test]
-    fn base_damage_thunder_ring_matches_table() {
-        let expected = [40.0, 50.0, 60.0, 60.0, 70.0, 80.0, 90.0, 100.0];
+    fn base_damage_thunder_ring_matches_ron_config() {
+        use crate::config::weapon::ThunderRingConfig;
+        let cfg: ThunderRingConfig = ron::de::from_str(include_str!(
+            "../../../vampire-survivors/assets/config/weapons/thunder_ring.ron"
+        ))
+        .expect("thunder_ring.ron should parse");
         let mut state = WeaponState::new(WeaponType::ThunderRing);
-        for (i, &expected_dmg) in expected.iter().enumerate() {
+        for (i, &expected) in cfg.damage_by_level.iter().enumerate() {
             state.level = (i + 1) as u8;
-            assert_eq!(state.base_damage(), expected_dmg, "ThunderRing lv{}", i + 1);
+            assert_eq!(state.base_damage(), expected, "ThunderRing lv{}", i + 1);
         }
     }
 
-    /// Cross damage matches the RON config table.
+    /// Cross base_damage() matches the per-level table in cross.ron.
     #[test]
-    fn base_damage_cross_matches_table() {
-        let expected = [50.0, 60.0, 70.0, 80.0, 90.0, 110.0, 130.0, 160.0];
+    fn base_damage_cross_matches_ron_config() {
+        use crate::config::weapon::CrossConfig;
+        let cfg: CrossConfig = ron::de::from_str(include_str!(
+            "../../../vampire-survivors/assets/config/weapons/cross.ron"
+        ))
+        .expect("cross.ron should parse");
         let mut state = WeaponState::new(WeaponType::Cross);
-        for (i, &expected_dmg) in expected.iter().enumerate() {
+        for (i, &expected) in cfg.damage_by_level.iter().enumerate() {
             state.level = (i + 1) as u8;
-            assert_eq!(state.base_damage(), expected_dmg, "Cross lv{}", i + 1);
+            assert_eq!(state.base_damage(), expected, "Cross lv{}", i + 1);
         }
     }
 
-    /// FireWand damage matches the RON config table.
+    /// FireWand base_damage() matches the per-level table in fire_wand.ron.
     #[test]
-    fn base_damage_fire_wand_matches_table() {
-        let expected = [80.0, 100.0, 120.0, 150.0, 180.0, 220.0, 270.0, 330.0];
+    fn base_damage_fire_wand_matches_ron_config() {
+        use crate::config::weapon::FireWandConfig;
+        let cfg: FireWandConfig = ron::de::from_str(include_str!(
+            "../../../vampire-survivors/assets/config/weapons/fire_wand.ron"
+        ))
+        .expect("fire_wand.ron should parse");
         let mut state = WeaponState::new(WeaponType::FireWand);
-        for (i, &expected_dmg) in expected.iter().enumerate() {
+        for (i, &expected) in cfg.damage_by_level.iter().enumerate() {
             state.level = (i + 1) as u8;
-            assert_eq!(state.base_damage(), expected_dmg, "FireWand lv{}", i + 1);
+            assert_eq!(state.base_damage(), expected, "FireWand lv{}", i + 1);
         }
     }
 
@@ -495,52 +593,63 @@ mod tests {
         }
     }
 
-    /// Knife count matches the RON config table.
+    /// Knife base_count() matches the per-level table in knife.ron.
     #[test]
-    fn base_count_knife_matches_table() {
-        let expected = [1u32, 1, 2, 2, 3, 3, 4, 5];
+    fn base_count_knife_matches_ron_config() {
+        use crate::config::weapon::KnifeConfig;
+        let cfg: KnifeConfig = ron::de::from_str(include_str!(
+            "../../../vampire-survivors/assets/config/weapons/knife.ron"
+        ))
+        .expect("knife.ron should parse");
         let mut state = WeaponState::new(WeaponType::Knife);
-        for (i, &expected_count) in expected.iter().enumerate() {
+        for (i, &expected) in cfg.count_by_level.iter().enumerate() {
             state.level = (i + 1) as u8;
-            assert_eq!(state.base_count(), expected_count, "Knife lv{}", i + 1);
+            assert_eq!(state.base_count(), expected, "Knife lv{}", i + 1);
         }
     }
 
-    /// Bible count matches the RON config table.
+    /// Bible base_count() matches the per-level table in bible.ron.
     #[test]
-    fn base_count_bible_matches_table() {
-        let expected = [1u32, 1, 2, 2, 3, 3, 3, 3];
+    fn base_count_bible_matches_ron_config() {
+        use crate::config::weapon::BibleConfig;
+        let cfg: BibleConfig = ron::de::from_str(include_str!(
+            "../../../vampire-survivors/assets/config/weapons/bible.ron"
+        ))
+        .expect("bible.ron should parse");
         let mut state = WeaponState::new(WeaponType::Bible);
-        for (i, &expected_count) in expected.iter().enumerate() {
+        for (i, &expected) in cfg.count_by_level.iter().enumerate() {
             state.level = (i + 1) as u8;
-            assert_eq!(state.base_count(), expected_count, "Bible lv{}", i + 1);
+            assert_eq!(state.base_count(), expected, "Bible lv{}", i + 1);
         }
     }
 
-    /// ThunderRing count matches the RON config table.
+    /// ThunderRing base_count() matches the per-level table in thunder_ring.ron.
     #[test]
-    fn base_count_thunder_ring_matches_table() {
-        let expected = [1u32, 1, 2, 2, 3, 3, 3, 4];
+    fn base_count_thunder_ring_matches_ron_config() {
+        use crate::config::weapon::ThunderRingConfig;
+        let cfg: ThunderRingConfig = ron::de::from_str(include_str!(
+            "../../../vampire-survivors/assets/config/weapons/thunder_ring.ron"
+        ))
+        .expect("thunder_ring.ron should parse");
         let mut state = WeaponState::new(WeaponType::ThunderRing);
-        for (i, &expected_count) in expected.iter().enumerate() {
+        for (i, &expected) in cfg.count_by_level.iter().enumerate() {
             state.level = (i + 1) as u8;
-            assert_eq!(
-                state.base_count(),
-                expected_count,
-                "ThunderRing lv{}",
-                i + 1
-            );
+            assert_eq!(state.base_count(), expected, "ThunderRing lv{}", i + 1);
         }
     }
 
-    /// Cross count matches the RON config table.
+    /// Cross base_count() matches the per-level table in cross.ron.
     #[test]
-    fn base_count_cross_matches_table() {
-        let expected = [1u32, 1, 1, 1, 2, 2, 2, 2];
+    fn base_count_cross_matches_ron_config() {
+        use crate::config::weapon::CrossConfig;
+        let cfg: CrossConfig = ron::de::from_str(include_str!(
+            "../../../vampire-survivors/assets/config/weapons/cross.ron"
+        ))
+        .expect("cross.ron should parse");
         let mut state = WeaponState::new(WeaponType::Cross);
-        for (i, &expected_count) in expected.iter().enumerate() {
+        for (i, &expected) in cfg.count_by_level.iter().enumerate() {
             state.level = (i + 1) as u8;
-            assert_eq!(state.base_count(), expected_count, "Cross lv{}", i + 1);
+            assert_eq!(state.base_count(), expected, "Cross lv{}", i + 1);
         }
     }
 


### PR DESCRIPTION
## 概要

- `WeaponState::base_damage()` メソッドを追加 — 全8武器のLv1〜8のダメージ値を返す
- `WeaponState::base_count()` メソッドを追加 — 全8武器のLv1〜8の発射数を返す
- 既存の `base_cooldown()` と同じパターンで実装（RONアセットが未ロードでも使用可能）

Closes: #42 

## 変更内容

### `WeaponState::base_damage()`

各武器のダメージ計算式:

| 武器 | 計算式 | Lv1→Lv8 |
|------|--------|---------|
| Whip / MagicWand | 20 + 10×(lv-1) | 20 → 90 |
| Knife | 15 + 5×floor((lv-1)/2) | 15 → 30 |
| Garlic | テーブル参照 | 5 → 20 |
| Bible | テーブル参照 | 20 → 80 |
| ThunderRing | テーブル参照 | 40 → 100 |
| Cross | テーブル参照 | 50 → 160 |
| FireWand | テーブル参照 | 80 → 330 |

テーブル値はRON設定ファイル(`assets/config/weapons/`)の値と一致。

### `WeaponState::base_count()`

| 武器 | Lv1 | Lv4 | Lv8 |
|------|-----|-----|-----|
| Whip / MagicWand / Garlic / FireWand | 1 | 1 | 1 |
| Knife | 1 | 2 | 5 |
| Bible | 1 | 2 | 3 |
| ThunderRing | 1 | 2 | 4 |
| Cross | 1 | 1 | 2 |

進化後武器は最大レベルの固定値を返す。

## テスト

16件の新規ユニットテストを追加:
- 各武器ごとのテーブル一致確認
- 全武器でレベルが上がるにつれてダメージ・発射数が単調増加することを確認
- level=0の境界値クランプ確認

## チェックリスト

- [x] `just fmt` 実行済み
- [x] `just clippy` 警告なし
- [x] `just test` 全テスト通過（319件）

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced weapon mechanics: more accurate per-weapon base damage and projectile counts with level-based scaling, evolved-weapon handling, and graceful fallbacks when asset data is unavailable.

* **Tests**
  * Added extensive validation of weapon damage/count behavior across levels, including monotonicity and clamping checks to ensure consistent in-game progression.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->