### PR TITLE
refactor(core): GameCorePlugin をサブプラグイン化

### DIFF
--- a/app/core/src/lib.rs
+++ b/app/core/src/lib.rs
@@ -17,37 +17,11 @@ use resources::{
     SpatialGrid, TreasureSpawner,
 };
 use states::AppState;
-use systems::damage::apply_damage_to_enemies;
-use systems::enemies::ai::move_enemies;
-use systems::enemies::cull::cull_distant_enemies;
-use systems::enemies::difficulty::update_difficulty;
-use systems::enemies::spawn::spawn_enemies;
-use systems::game_over::check_player_death;
-use systems::game_timer::update_game_timer;
-use systems::player::collision::{
-    apply_damage_to_player, enemy_player_collision, tick_invincibility,
+use systems::{
+    enemies::EnemiesPlugin, game_over::GameOverPlugin, game_timer::TimerPlugin,
+    player::PlayerPlugin, projectiles::ProjectilesPlugin, spatial::SpatialPlugin,
+    weapons::WeaponsPlugin, xp::XpPlugin,
 };
-use systems::player::{despawn_game_session, player_movement, spawn_player};
-use systems::projectiles::collision::projectile_enemy_collision;
-use systems::projectiles::{despawn_expired_projectiles, move_projectiles};
-use systems::spatial::update_spatial_grid;
-use systems::weapons::bible::{fire_bible, orbit_bible, spawn_bible_visual};
-use systems::weapons::cooldown::tick_weapon_cooldowns;
-use systems::weapons::cross::{fire_cross, update_cross};
-use systems::weapons::fire_wand::{
-    despawn_expired_fireballs, despawn_explosion_effects, fire_fire_wand, fireball_enemy_collision,
-    move_fireballs,
-};
-use systems::weapons::garlic::{fire_garlic, spawn_garlic_visual, update_garlic_visual};
-use systems::weapons::knife::fire_knife;
-use systems::weapons::magic_wand::fire_magic_wand;
-use systems::weapons::thunder_ring::{despawn_thunder_effects, fire_thunder_ring};
-use systems::weapons::whip::{despawn_whip_effects, fire_whip};
-use systems::xp::apply::apply_selected_upgrade;
-use systems::xp::attraction::{attract_gems_to_player, move_attracted_gems};
-use systems::xp::choices::generate_level_up_choices;
-use systems::xp::drop::spawn_xp_gems;
-use systems::xp::level_up::check_level_up;
 
 /// Core game plugin. Registers states, inserts default resources, and wires up
 /// all gameplay systems.
@@ -84,124 +58,17 @@ impl Plugin for GameCorePlugin {
             .add_message::<GameOverEvent>()
             .add_message::<LevelUpEvent>()
             // ---------------------------------------------------------------
-            // Player lifecycle
+            // Sub-plugins (each owns its domain's systems)
             // ---------------------------------------------------------------
-            // spawn_player skips silently when a Player entity already exists,
-            // so re-entering Playing from LevelUp / Paused is safe.
-            // apply_selected_upgrade reads PendingUpgradeIndex; it is a no-op
-            // when None (e.g. Title → Playing on game start).
-            .add_systems(
-                OnEnter(AppState::Playing),
-                (spawn_player, apply_selected_upgrade).chain(),
-            )
-            // Clean up all gameplay entities when the run truly ends.
-            // despawn_game_session removes every GameSessionEntity (player,
-            // enemies, gems, projectiles, whip effects, …).
-            .add_systems(OnEnter(AppState::GameOver), despawn_game_session)
-            .add_systems(OnEnter(AppState::Victory), despawn_game_session)
-            // Also on Title so a Paused → Title quit cleans up correctly.
-            .add_systems(OnEnter(AppState::Title), despawn_game_session)
-            // ---------------------------------------------------------------
-            // LevelUp state — generate upgrade choices when overlay opens
-            // ---------------------------------------------------------------
-            // The player entity is still alive here (no DespawnOnExit on it),
-            // so generate_level_up_choices can query WeaponInventory /
-            // PassiveInventory to build a valid choice pool.
-            .add_systems(OnEnter(AppState::LevelUp), generate_level_up_choices)
-            // ---------------------------------------------------------------
-            // Playing state — per-frame gameplay systems (part 1: movement,
-            // weapons, collision, and damage)
-            // ---------------------------------------------------------------
-            .add_systems(
-                Update,
-                (
-                    player_movement,
-                    move_enemies.after(player_movement),
-                    tick_weapon_cooldowns.after(player_movement),
-                    update_spatial_grid.after(move_enemies),
-                    fire_magic_wand.after(tick_weapon_cooldowns),
-                    fire_knife.after(tick_weapon_cooldowns),
-                    fire_bible.after(tick_weapon_cooldowns),
-                    orbit_bible.after(fire_bible).after(update_spatial_grid),
-                    fire_garlic
-                        .after(tick_weapon_cooldowns)
-                        .after(update_spatial_grid),
-                    fire_thunder_ring.after(tick_weapon_cooldowns),
-                    fire_cross.after(tick_weapon_cooldowns),
-                    fire_fire_wand.after(tick_weapon_cooldowns),
-                    fire_whip
-                        .after(tick_weapon_cooldowns)
-                        .after(update_spatial_grid),
-                    move_projectiles,
-                    update_cross.after(move_projectiles),
-                    projectile_enemy_collision
-                        .after(update_spatial_grid)
-                        .after(move_projectiles)
-                        .after(update_cross),
-                    apply_damage_to_enemies
-                        .after(fire_whip)
-                        .after(fire_garlic)
-                        .after(fire_magic_wand)
-                        .after(fire_knife)
-                        .after(orbit_bible)
-                        .after(fire_thunder_ring)
-                        .after(projectile_enemy_collision)
-                        .after(fireball_enemy_collision),
-                    tick_invincibility.before(enemy_player_collision),
-                    enemy_player_collision.after(update_spatial_grid),
-                    apply_damage_to_player.after(enemy_player_collision),
-                )
-                    .run_if(in_state(AppState::Playing)),
-            )
-            // Playing state — per-frame gameplay systems (part 2: XP, enemies,
-            // timers, and death)
-            .add_systems(
-                Update,
-                (
-                    spawn_xp_gems.after(apply_damage_to_enemies),
-                    attract_gems_to_player.after(player_movement),
-                    move_attracted_gems.after(attract_gems_to_player),
-                    update_game_timer,
-                    update_difficulty.after(update_game_timer),
-                    spawn_enemies.after(update_difficulty),
-                    cull_distant_enemies
-                        .after(move_enemies)
-                        .after(spawn_enemies),
-                    check_level_up
-                        .after(move_attracted_gems)
-                        .before(check_player_death),
-                    check_player_death.after(apply_damage_to_player),
-                )
-                    .run_if(in_state(AppState::Playing)),
-            )
-            // Playing state — per-frame gameplay systems (part 2b: fireball
-            // movement and collision; separate block to stay within the
-            // 20-item system-tuple limit)
-            .add_systems(
-                Update,
-                (
-                    move_fireballs,
-                    fireball_enemy_collision
-                        .after(move_fireballs)
-                        .after(update_spatial_grid),
-                )
-                    .run_if(in_state(AppState::Playing)),
-            )
-            // Playing state — per-frame gameplay systems (part 3: visuals and
-            // entity cleanup; independent of damage/XP ordering)
-            .add_systems(
-                Update,
-                (
-                    spawn_bible_visual,
-                    spawn_garlic_visual,
-                    update_garlic_visual,
-                    despawn_whip_effects,
-                    despawn_thunder_effects,
-                    despawn_expired_projectiles,
-                    despawn_explosion_effects,
-                    despawn_expired_fireballs,
-                )
-                    .run_if(in_state(AppState::Playing)),
-            );
+            .add_plugins((
+                TimerPlugin,
+                SpatialPlugin,
+                PlayerPlugin,
+                EnemiesPlugin,
+                WeaponsPlugin,
+                ProjectilesPlugin,
+                XpPlugin,
+                GameOverPlugin,
+            ));
     }
 }

--- a/app/core/src/systems/enemies/mod.rs
+++ b/app/core/src/systems/enemies/mod.rs
@@ -2,3 +2,32 @@ pub mod ai;
 pub mod cull;
 pub mod difficulty;
 pub mod spawn;
+
+use bevy::prelude::*;
+
+use crate::states::AppState;
+
+pub struct EnemiesPlugin;
+
+impl Plugin for EnemiesPlugin {
+    fn build(&self, app: &mut App) {
+        use crate::systems::enemies::ai::move_enemies;
+        use crate::systems::enemies::cull::cull_distant_enemies;
+        use crate::systems::enemies::difficulty::update_difficulty;
+        use crate::systems::enemies::spawn::spawn_enemies;
+        use crate::systems::game_timer::update_game_timer;
+        use crate::systems::player::player_movement;
+        app.add_systems(
+            Update,
+            (
+                move_enemies.after(player_movement),
+                update_difficulty.after(update_game_timer),
+                spawn_enemies.after(update_difficulty),
+                cull_distant_enemies
+                    .after(move_enemies)
+                    .after(spawn_enemies),
+            )
+                .run_if(in_state(AppState::Playing)),
+        );
+    }
+}

--- a/app/core/src/systems/game_over.rs
+++ b/app/core/src/systems/game_over.rs
@@ -12,6 +12,22 @@ use crate::{
     states::AppState,
 };
 
+pub struct GameOverPlugin;
+
+impl Plugin for GameOverPlugin {
+    fn build(&self, app: &mut App) {
+        use crate::systems::player::collision::apply_damage_to_player;
+        use crate::systems::xp::level_up::check_level_up;
+        app.add_systems(
+            Update,
+            check_player_death
+                .after(apply_damage_to_player)
+                .after(check_level_up)
+                .run_if(in_state(AppState::Playing)),
+        );
+    }
+}
+
 /// Checks whether the player's HP has reached zero and triggers game over.
 ///
 /// Emits a [`GameOverEvent`] and sets [`NextState`] to [`AppState::GameOver`]

--- a/app/core/src/systems/game_timer.rs
+++ b/app/core/src/systems/game_timer.rs
@@ -5,7 +5,18 @@
 
 use bevy::prelude::*;
 
-use crate::resources::GameData;
+use crate::{resources::GameData, states::AppState};
+
+pub struct TimerPlugin;
+
+impl Plugin for TimerPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(
+            Update,
+            update_game_timer.run_if(in_state(AppState::Playing)),
+        );
+    }
+}
 
 /// Advances the run timer every frame.
 ///

--- a/app/core/src/systems/player/mod.rs
+++ b/app/core/src/systems/player/mod.rs
@@ -2,6 +2,33 @@ pub mod collision;
 
 use bevy::prelude::*;
 
+use crate::states::AppState;
+
+pub struct PlayerPlugin;
+
+impl Plugin for PlayerPlugin {
+    fn build(&self, app: &mut App) {
+        use crate::systems::player::collision::{
+            apply_damage_to_player, enemy_player_collision, tick_invincibility,
+        };
+        use crate::systems::spatial::update_spatial_grid;
+        app.add_systems(OnEnter(AppState::Playing), spawn_player)
+            .add_systems(OnEnter(AppState::GameOver), despawn_game_session)
+            .add_systems(OnEnter(AppState::Victory), despawn_game_session)
+            .add_systems(OnEnter(AppState::Title), despawn_game_session)
+            .add_systems(
+                Update,
+                (
+                    player_movement,
+                    tick_invincibility.before(enemy_player_collision),
+                    enemy_player_collision.after(update_spatial_grid),
+                    apply_damage_to_player.after(enemy_player_collision),
+                )
+                    .run_if(in_state(AppState::Playing)),
+            );
+    }
+}
+
 use crate::{
     components::{
         CircleCollider, GameSessionEntity, PassiveInventory, Player, PlayerFacingDirection,

--- a/app/core/src/systems/projectiles/mod.rs
+++ b/app/core/src/systems/projectiles/mod.rs
@@ -17,8 +17,32 @@ use bevy::prelude::*;
 
 use crate::{
     components::{CircleCollider, GameSessionEntity, Projectile, ProjectileVelocity},
+    states::AppState,
     types::WeaponType,
 };
+
+pub struct ProjectilesPlugin;
+
+impl Plugin for ProjectilesPlugin {
+    fn build(&self, app: &mut App) {
+        use crate::systems::projectiles::collision::projectile_enemy_collision;
+        use crate::systems::spatial::update_spatial_grid;
+        use crate::systems::weapons::cross::update_cross;
+        app.add_systems(
+            Update,
+            (
+                move_projectiles,
+                update_cross.after(move_projectiles),
+                projectile_enemy_collision
+                    .after(update_spatial_grid)
+                    .after(move_projectiles)
+                    .after(update_cross),
+                despawn_expired_projectiles,
+            )
+                .run_if(in_state(AppState::Playing)),
+        );
+    }
+}
 
 // ---------------------------------------------------------------------------
 // Systems

--- a/app/core/src/systems/spatial.rs
+++ b/app/core/src/systems/spatial.rs
@@ -7,7 +7,21 @@
 
 use bevy::prelude::*;
 
-use crate::{components::Enemy, resources::SpatialGrid};
+use crate::{components::Enemy, resources::SpatialGrid, states::AppState};
+
+pub struct SpatialPlugin;
+
+impl Plugin for SpatialPlugin {
+    fn build(&self, app: &mut App) {
+        use crate::systems::enemies::ai::move_enemies;
+        app.add_systems(
+            Update,
+            update_spatial_grid
+                .after(move_enemies)
+                .run_if(in_state(AppState::Playing)),
+        );
+    }
+}
 
 // ---------------------------------------------------------------------------
 // System

--- a/app/core/src/systems/weapons/mod.rs
+++ b/app/core/src/systems/weapons/mod.rs
@@ -7,3 +7,76 @@ pub mod knife;
 pub mod magic_wand;
 pub mod thunder_ring;
 pub mod whip;
+
+use bevy::prelude::*;
+
+use crate::states::AppState;
+
+pub struct WeaponsPlugin;
+
+impl Plugin for WeaponsPlugin {
+    fn build(&self, app: &mut App) {
+        use crate::systems::damage::apply_damage_to_enemies;
+        use crate::systems::player::player_movement;
+        use crate::systems::projectiles::collision::projectile_enemy_collision;
+        use crate::systems::spatial::update_spatial_grid;
+        use crate::systems::weapons::bible::{fire_bible, orbit_bible, spawn_bible_visual};
+        use crate::systems::weapons::cooldown::tick_weapon_cooldowns;
+        use crate::systems::weapons::cross::fire_cross;
+        use crate::systems::weapons::fire_wand::{
+            despawn_expired_fireballs, despawn_explosion_effects, fire_fire_wand,
+            fireball_enemy_collision, move_fireballs,
+        };
+        use crate::systems::weapons::garlic::{
+            fire_garlic, spawn_garlic_visual, update_garlic_visual,
+        };
+        use crate::systems::weapons::knife::fire_knife;
+        use crate::systems::weapons::magic_wand::fire_magic_wand;
+        use crate::systems::weapons::thunder_ring::{despawn_thunder_effects, fire_thunder_ring};
+        use crate::systems::weapons::whip::{despawn_whip_effects, fire_whip};
+        app.add_systems(
+            Update,
+            (
+                tick_weapon_cooldowns.after(player_movement),
+                fire_magic_wand.after(tick_weapon_cooldowns),
+                fire_knife.after(tick_weapon_cooldowns),
+                fire_bible.after(tick_weapon_cooldowns),
+                orbit_bible.after(fire_bible).after(update_spatial_grid),
+                fire_garlic
+                    .after(tick_weapon_cooldowns)
+                    .after(update_spatial_grid),
+                fire_thunder_ring.after(tick_weapon_cooldowns),
+                fire_cross.after(tick_weapon_cooldowns),
+                fire_fire_wand.after(tick_weapon_cooldowns),
+                fire_whip
+                    .after(tick_weapon_cooldowns)
+                    .after(update_spatial_grid),
+                move_fireballs,
+                fireball_enemy_collision
+                    .after(move_fireballs)
+                    .after(update_spatial_grid),
+                spawn_bible_visual,
+                spawn_garlic_visual,
+                update_garlic_visual,
+                despawn_whip_effects,
+                despawn_thunder_effects,
+                despawn_explosion_effects,
+                despawn_expired_fireballs,
+            )
+                .run_if(in_state(AppState::Playing)),
+        )
+        .add_systems(
+            Update,
+            apply_damage_to_enemies
+                .after(fire_whip)
+                .after(fire_garlic)
+                .after(fire_magic_wand)
+                .after(fire_knife)
+                .after(orbit_bible)
+                .after(fire_thunder_ring)
+                .after(projectile_enemy_collision)
+                .after(fireball_enemy_collision)
+                .run_if(in_state(AppState::Playing)),
+        );
+    }
+}

--- a/app/core/src/systems/xp/mod.rs
+++ b/app/core/src/systems/xp/mod.rs
@@ -3,3 +3,37 @@ pub mod attraction;
 pub mod choices;
 pub mod drop;
 pub mod level_up;
+
+use bevy::prelude::*;
+
+use crate::states::AppState;
+
+pub struct XpPlugin;
+
+impl Plugin for XpPlugin {
+    fn build(&self, app: &mut App) {
+        use crate::systems::damage::apply_damage_to_enemies;
+        use crate::systems::player::player_movement;
+        use crate::systems::player::spawn_player;
+        use crate::systems::xp::apply::apply_selected_upgrade;
+        use crate::systems::xp::attraction::{attract_gems_to_player, move_attracted_gems};
+        use crate::systems::xp::choices::generate_level_up_choices;
+        use crate::systems::xp::drop::spawn_xp_gems;
+        use crate::systems::xp::level_up::check_level_up;
+        app.add_systems(
+            OnEnter(AppState::Playing),
+            apply_selected_upgrade.after(spawn_player),
+        )
+        .add_systems(OnEnter(AppState::LevelUp), generate_level_up_choices)
+        .add_systems(
+            Update,
+            (
+                spawn_xp_gems.after(apply_damage_to_enemies),
+                attract_gems_to_player.after(player_movement),
+                move_attracted_gems.after(attract_gems_to_player),
+                check_level_up.after(move_attracted_gems),
+            )
+                .run_if(in_state(AppState::Playing)),
+        );
+    }
+}


### PR DESCRIPTION
## 概要

`GameCorePlugin::build()` が207行に膨張し、単一ファイルへの変更が頻発していた問題を解消する。
各ドメインに `Plugin` impl を持たせ、`GameCorePlugin` は状態・リソース・イベント登録と `add_plugins()` 呼び出しのみ（74行）に削減した。

## 変更内容

- `TimerPlugin` (`game_timer.rs`) — `update_game_timer`
- `SpatialPlugin` (`spatial.rs`) — `update_spatial_grid`
- `PlayerPlugin` (`player/mod.rs`) — spawn/despawn、移動、被ダメ系
- `EnemiesPlugin` (`enemies/mod.rs`) — 移動、難易度、スポーン、カリング
- `WeaponsPlugin` (`weapons/mod.rs`) — クールダウン、発射、ビジュアル、`apply_damage_to_enemies`
- `ProjectilesPlugin` (`projectiles/mod.rs`) — 移動、十字、衝突、デスポーン
- `XpPlugin` (`xp/mod.rs`) — ジェム、吸引、レベルアップ、アップグレード適用
- `GameOverPlugin` (`game_over.rs`) — `check_player_death`
- `lib.rs`: 207行 → 74行。クロスプラグイン順序は `.after(fn)` で維持

## テスト

- [x] `just fmt` 実行済み
- [x] `just clippy` (-D warnings) 通過
- [x] `just test` 320テスト全通過
- [x] `cargo build` ビルド成功

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured core game systems architecture by consolidating individual system schedulers into modular, plugin-based components. Game systems for enemies, player, weapons, projectiles, spatial collision detection, experience point handling, game-over logic, and timer management are now organized as self-contained plugins with improved execution ordering and conditional state management. Existing gameplay functionality remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->