### PR TITLE
test(xp): パッシブ新規取得の選択肢テストを追加 (#44)

### DIFF
--- a/app/core/src/systems/xp/choices.rs
+++ b/app/core/src/systems/xp/choices.rs
@@ -421,6 +421,37 @@ mod tests {
 
     // --- Passive eligibility ---
 
+    /// Unowned passive appears as PassiveItem choice when a slot is open.
+    #[test]
+    fn unowned_passive_appears_as_new_passive_choice() {
+        let mut app = build_app();
+        // All weapons at max level → no weapon choices in pool.
+        // No passives owned → all 9 unowned; slot available.
+        let weapons: Vec<WeaponState> = BASE_WEAPONS
+            .iter()
+            .take(DEFAULT_MAX_WEAPONS)
+            .map(|&wt| {
+                let mut ws = WeaponState::new(wt);
+                ws.level = DEFAULT_MAX_WEAPON_LEVEL;
+                ws
+            })
+            .collect();
+        spawn_player(&mut app, weapons, vec![]);
+        run(&mut app);
+
+        let c = choices(&app);
+        assert_eq!(
+            c.len(),
+            DEFAULT_CHOICE_COUNT,
+            "expected {DEFAULT_CHOICE_COUNT} choices from passive pool"
+        );
+        assert!(
+            c.iter()
+                .all(|ch| matches!(ch, UpgradeChoice::PassiveItem(_))),
+            "all choices should be PassiveItem when no passives are owned: {c:?}"
+        );
+    }
+
     /// Owned passive below max level appears as PassiveUpgrade.
     #[test]
     fn owned_passive_below_max_is_upgradeable() {


### PR DESCRIPTION
## 概要

Issue #44 の受け入れ基準はすべて `generate_level_up_choices` に実装済み。未取得パッシブが `PassiveItem` として選択肢に出るという陽性ケースのテストが欠落していたため追加した。

## 変更内容

- `unowned_passive_appears_as_new_passive_choice` テスト追加 (`systems/xp/choices.rs`)
  - 全武器マックスレベル・パッシブ未所持の状態で `generate_level_up_choices` を実行
  - `DEFAULT_CHOICE_COUNT` 件の `PassiveItem` 選択肢が生成されることを確認

## 受け入れ基準の対応状況

| 基準 | 対応コード | テスト |
|------|-----------|--------|
| 未取得パッシブが「新規取得」として出る | `pool.push(PassiveItem(...))` | ✅ 今回追加 |
| Lv5未満の取得済みパッシブが「レベルアップ」として出る | `pool.push(PassiveUpgrade(...))` | ✅ `owned_passive_below_max_is_upgradeable` |
| Lv5のパッシブは除外される | `level < max_passive_level` | ✅ `max_level_passive_excluded` |

## テスト

- [x] `just fmt` / `just clippy` 通過
- [x] `just test` 333テスト全通過（1件新規追加）

Closes #44

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for passive item selection in the choice system, including a new test that validates the correct behavior when no passives are currently owned and item slots are available. The test ensures passive options are presented with the appropriate number of available choices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->