### PR TITLE
feat(enemies): implement Dragon enemy (Phase 9, issue #53)

### DIFF
--- a/app/core/src/components/enemy.rs
+++ b/app/core/src/components/enemy.rs
@@ -13,7 +13,7 @@ const DEFAULT_ENEMY_STATS_ZOMBIE: (f32, f32, f32, u32, f32) = (60.0, 60.0, 12.0,
 const DEFAULT_ENEMY_STATS_GHOST: (f32, f32, f32, u32, f32) = (25.0, 100.0, 10.0, 6, 0.08);
 const DEFAULT_ENEMY_STATS_DEMON: (f32, f32, f32, u32, f32) = (80.0, 130.0, 15.0, 10, 0.12);
 const DEFAULT_ENEMY_STATS_MEDUSA: (f32, f32, f32, u32, f32) = (60.0, 60.0, 12.0, 8, 0.10);
-const DEFAULT_ENEMY_STATS_DRAGON: (f32, f32, f32, u32, f32) = (200.0, 80.0, 20.0, 15, 0.15);
+const DEFAULT_ENEMY_STATS_DRAGON: (f32, f32, f32, u32, f32) = (150.0, 90.0, 25.0, 15, 0.15);
 const DEFAULT_ENEMY_STATS_BOSS_DEATH: (f32, f32, f32, u32, f32) = (5000.0, 30.0, 50.0, 500, 1.0);
 
 /// Core enemy stats. Attached to every enemy entity.
@@ -122,6 +122,21 @@ pub struct DamageFlash {
 /// when it hits the player.
 #[derive(Component, Debug)]
 pub struct MedusaProjectile {
+    /// Contact damage dealt to the player on hit.
+    pub damage: f32,
+    /// Velocity vector (pixels/second).
+    pub velocity: Vec2,
+    /// Remaining lifetime before the projectile despawns (seconds).
+    pub lifetime: f32,
+}
+
+/// Fireball projectile fired by the Dragon enemy.
+///
+/// Moves in a straight line toward the player's position at fire time.
+/// Despawns when [`lifetime`](DragonFireball::lifetime) reaches zero or
+/// when it hits the player.
+#[derive(Component, Debug)]
+pub struct DragonFireball {
     /// Contact damage dealt to the player on hit.
     pub damage: f32,
     /// Velocity vector (pixels/second).

--- a/app/core/src/config/enemy.rs
+++ b/app/core/src/config/enemy.rs
@@ -30,6 +30,23 @@ pub struct MedusaBehaviorConfig {
 }
 
 // ---------------------------------------------------------------------------
+// Dragon AI behavior config
+// ---------------------------------------------------------------------------
+
+/// Behavior parameters for the Dragon enemy, deserialized from RON.
+#[derive(Deserialize, Debug, Clone)]
+pub struct DragonBehaviorConfig {
+    /// Seconds between fireball shots.
+    pub attack_interval: f32,
+    /// Speed of the fired fireball (pixels/second).
+    pub fireball_speed: f32,
+    /// Lifetime of the fireball before it despawns (seconds).
+    pub fireball_lifetime: f32,
+    /// Collider radius of the fireball (pixels).
+    pub fireball_radius: f32,
+}
+
+// ---------------------------------------------------------------------------
 // Per-enemy stats entry
 // ---------------------------------------------------------------------------
 
@@ -78,8 +95,12 @@ pub struct EnemyConfig {
     pub demon_unlock_secs: f32,
     /// Seconds into the run before Medusas are added to the spawn table.
     pub medusa_unlock_secs: f32,
+    /// Seconds into the run before Dragons are added to the spawn table.
+    pub dragon_unlock_secs: f32,
     /// Medusa-specific AI and projectile behavior parameters.
     pub medusa_behavior: MedusaBehaviorConfig,
+    /// Dragon-specific fireball behavior parameters.
+    pub dragon_behavior: DragonBehaviorConfig,
 }
 
 impl EnemyConfig {
@@ -171,7 +192,7 @@ EnemyConfig(
     ghost: (base_hp: 25.0, speed: 100.0, damage: 10.0, xp_value: 6, gold_chance: 0.08, collider_radius: 10.0),
     demon: (base_hp: 80.0, speed: 130.0, damage: 15.0, xp_value: 10, gold_chance: 0.12, collider_radius: 14.0),
     medusa: (base_hp: 60.0, speed: 60.0, damage: 12.0, xp_value: 8, gold_chance: 0.10, collider_radius: 12.0),
-    dragon: (base_hp: 200.0, speed: 80.0, damage: 20.0, xp_value: 15, gold_chance: 0.15, collider_radius: 20.0),
+    dragon: (base_hp: 150.0, speed: 90.0, damage: 25.0, xp_value: 15, gold_chance: 0.15, collider_radius: 20.0),
     boss_death: (base_hp: 5000.0, speed: 30.0, damage: 50.0, xp_value: 500, gold_chance: 1.0, collider_radius: 30.0),
     spawn_base_interval: 0.5,
     max_count: 500,
@@ -182,6 +203,7 @@ EnemyConfig(
     ghost_unlock_secs: 600.0,
     demon_unlock_secs: 900.0,
     medusa_unlock_secs: 1200.0,
+    dragon_unlock_secs: 1500.0,
     medusa_behavior: (
         keep_min_dist: 150.0,
         keep_max_dist: 250.0,
@@ -189,6 +211,12 @@ EnemyConfig(
         projectile_speed: 180.0,
         projectile_lifetime: 5.0,
         projectile_radius: 5.0,
+    ),
+    dragon_behavior: (
+        attack_interval: 3.0,
+        fireball_speed: 200.0,
+        fireball_lifetime: 6.0,
+        fireball_radius: 7.0,
     ),
 )
 "#;
@@ -208,9 +236,12 @@ EnemyConfig(
         assert_eq!(config.ghost_unlock_secs, 600.0);
         assert_eq!(config.demon_unlock_secs, 900.0);
         assert_eq!(config.medusa_unlock_secs, 1200.0);
+        assert_eq!(config.dragon_unlock_secs, 1500.0);
         assert_eq!(config.medusa_behavior.keep_min_dist, 150.0);
         assert_eq!(config.medusa_behavior.keep_max_dist, 250.0);
         assert_eq!(config.medusa_behavior.attack_interval, 2.0);
+        assert_eq!(config.dragon_behavior.attack_interval, 3.0);
+        assert_eq!(config.dragon_behavior.fireball_speed, 200.0);
     }
 
     #[test]
@@ -223,7 +254,7 @@ EnemyConfig(
     ghost: (base_hp: 25.0, speed: 100.0, damage: 10.0, xp_value: 6, gold_chance: 0.08, collider_radius: 10.0),
     demon: (base_hp: 80.0, speed: 130.0, damage: 15.0, xp_value: 10, gold_chance: 0.12, collider_radius: 14.0),
     medusa: (base_hp: 60.0, speed: 60.0, damage: 12.0, xp_value: 8, gold_chance: 0.10, collider_radius: 12.0),
-    dragon: (base_hp: 200.0, speed: 80.0, damage: 20.0, xp_value: 15, gold_chance: 0.15, collider_radius: 20.0),
+    dragon: (base_hp: 150.0, speed: 90.0, damage: 25.0, xp_value: 15, gold_chance: 0.15, collider_radius: 20.0),
     boss_death: (base_hp: 5000.0, speed: 30.0, damage: 50.0, xp_value: 500, gold_chance: 1.0, collider_radius: 30.0),
     spawn_base_interval: 0.5,
     max_count: 500,
@@ -234,6 +265,7 @@ EnemyConfig(
     ghost_unlock_secs: 600.0,
     demon_unlock_secs: 900.0,
     medusa_unlock_secs: 1200.0,
+    dragon_unlock_secs: 1500.0,
     medusa_behavior: (
         keep_min_dist: 150.0,
         keep_max_dist: 250.0,
@@ -241,6 +273,12 @@ EnemyConfig(
         projectile_speed: 180.0,
         projectile_lifetime: 5.0,
         projectile_radius: 5.0,
+    ),
+    dragon_behavior: (
+        attack_interval: 3.0,
+        fireball_speed: 200.0,
+        fireball_lifetime: 6.0,
+        fireball_radius: 7.0,
     ),
 )
 "#;

--- a/app/core/src/systems/enemies/dragon.rs
+++ b/app/core/src/systems/enemies/dragon.rs
@@ -1,0 +1,410 @@
+//! Dragon enemy — melee-chase AI with ranged fireball attack.
+//!
+//! Three systems handle the Dragon's behavior:
+//!
+//! - [`tick_dragon_attack`] — advances `EnemyAI::attack_timer`; fires a
+//!   [`DragonFireball`] toward the player when the interval elapses.
+//! - [`move_dragon_fireballs`] — translates every active fireball along its
+//!   velocity vector and despawns it when its lifetime expires.
+//! - [`dragon_fireball_player_collision`] — checks each fireball against the
+//!   player's collider and emits a [`PlayerDamagedEvent`] on contact.
+
+use bevy::prelude::*;
+
+use crate::{
+    components::{
+        CircleCollider, DragonFireball, Enemy, EnemyAI, GameSessionEntity, InvincibilityTimer,
+        Player, PlayerStats,
+    },
+    config::{EnemyParams, PlayerParams},
+    events::PlayerDamagedEvent,
+    systems::collision::check_circle_collision,
+    types::{AIType, EnemyType},
+};
+
+// ---------------------------------------------------------------------------
+// Fallback constants (used when RON config is not yet loaded)
+// ---------------------------------------------------------------------------
+
+/// Seconds between Dragon fireball shots.
+const DEFAULT_DRAGON_ATTACK_INTERVAL: f32 = 3.0;
+/// Fireball speed in pixels/second.
+const DEFAULT_DRAGON_FIREBALL_SPEED: f32 = 200.0;
+/// Fireball lifetime in seconds before despawn.
+const DEFAULT_DRAGON_FIREBALL_LIFETIME: f32 = 6.0;
+/// Fireball collider radius in pixels.
+pub(crate) const DEFAULT_DRAGON_FIREBALL_RADIUS: f32 = 7.0;
+/// Invincibility duration granted after a fireball hit (seconds).
+const DEFAULT_FIREBALL_INVINCIBILITY: f32 = 0.5;
+
+// ---------------------------------------------------------------------------
+// Systems
+// ---------------------------------------------------------------------------
+
+/// Ticks `EnemyAI::attack_timer` for all Dragon enemies and fires a
+/// [`DragonFireball`] toward the player whenever the attack interval elapses.
+///
+/// Dragons use `ChasePlayer` AI for movement; this system adds the ranged
+/// attack on top without changing their movement behavior.
+pub fn tick_dragon_attack(
+    mut commands: Commands,
+    time: Res<Time>,
+    player_q: Query<&Transform, With<Player>>,
+    mut dragon_q: Query<(&Transform, &Enemy, &mut EnemyAI)>,
+    enemy_cfg: EnemyParams,
+) {
+    let Ok(player_tf) = player_q.single() else {
+        return;
+    };
+    let player_pos = player_tf.translation.truncate();
+
+    let attack_interval = enemy_cfg
+        .get()
+        .map(|c| c.dragon_behavior.attack_interval)
+        .unwrap_or(DEFAULT_DRAGON_ATTACK_INTERVAL)
+        .max(0.1);
+    let fireball_speed = enemy_cfg
+        .get()
+        .map(|c| c.dragon_behavior.fireball_speed)
+        .unwrap_or(DEFAULT_DRAGON_FIREBALL_SPEED)
+        .max(1.0);
+    let fireball_lifetime = enemy_cfg
+        .get()
+        .map(|c| c.dragon_behavior.fireball_lifetime)
+        .unwrap_or(DEFAULT_DRAGON_FIREBALL_LIFETIME)
+        .max(0.1);
+    let fireball_radius = enemy_cfg
+        .get()
+        .map(|c| c.dragon_behavior.fireball_radius)
+        .unwrap_or(DEFAULT_DRAGON_FIREBALL_RADIUS);
+
+    let dt = time.delta_secs();
+
+    for (dragon_tf, enemy, mut ai) in dragon_q.iter_mut() {
+        if enemy.enemy_type != EnemyType::Dragon || ai.ai_type != AIType::ChasePlayer {
+            continue;
+        }
+
+        ai.attack_timer += dt;
+        if ai.attack_timer < attack_interval {
+            continue;
+        }
+        ai.attack_timer = 0.0;
+
+        let origin = dragon_tf.translation.truncate();
+        let direction = (player_pos - origin).normalize_or_zero();
+        if direction == Vec2::ZERO {
+            continue; // player is exactly on Dragon — skip
+        }
+
+        commands.spawn((
+            DragonFireball {
+                damage: enemy.damage,
+                velocity: direction * fireball_speed,
+                lifetime: fireball_lifetime,
+            },
+            CircleCollider {
+                radius: fireball_radius,
+            },
+            Sprite {
+                color: Color::srgb(1.0, 0.4, 0.0),
+                custom_size: Some(Vec2::splat(fireball_radius * 2.0)),
+                ..default()
+            },
+            Transform::from_translation(origin.extend(4.0)),
+            GameSessionEntity,
+        ));
+    }
+}
+
+/// Advances every [`DragonFireball`] along its velocity vector and despawns
+/// those whose lifetime has expired.
+pub fn move_dragon_fireballs(
+    mut commands: Commands,
+    time: Res<Time>,
+    mut fireball_q: Query<(Entity, &mut Transform, &mut DragonFireball)>,
+) {
+    let dt = time.delta_secs();
+    for (entity, mut tf, mut fireball) in fireball_q.iter_mut() {
+        tf.translation += (fireball.velocity * dt).extend(0.0);
+        fireball.lifetime -= dt;
+        if fireball.lifetime <= 0.0 {
+            commands.entity(entity).despawn();
+        }
+    }
+}
+
+/// Checks every active [`DragonFireball`] against the player's circle
+/// collider.  On contact the fireball is despawned and a
+/// [`PlayerDamagedEvent`] is emitted.  Respects the player's
+/// [`InvincibilityTimer`].
+#[allow(clippy::type_complexity)]
+pub fn dragon_fireball_player_collision(
+    mut commands: Commands,
+    player_q: Query<
+        (Entity, &Transform, &CircleCollider, &PlayerStats),
+        (With<Player>, Without<InvincibilityTimer>),
+    >,
+    fireball_q: Query<(Entity, &Transform, &CircleCollider, &DragonFireball)>,
+    player_cfg: PlayerParams,
+    mut damage_events: MessageWriter<PlayerDamagedEvent>,
+) {
+    let Ok((player_entity, player_tf, player_collider, _)) = player_q.single() else {
+        return;
+    };
+    let player_pos = player_tf.translation.truncate();
+
+    let invincibility_duration = player_cfg
+        .get()
+        .map(|c| c.invincibility_time)
+        .unwrap_or(DEFAULT_FIREBALL_INVINCIBILITY);
+
+    for (fireball_entity, fireball_tf, fireball_collider, fireball) in fireball_q.iter() {
+        let fireball_pos = fireball_tf.translation.truncate();
+        if !check_circle_collision(
+            player_pos,
+            player_collider.radius,
+            fireball_pos,
+            fireball_collider.radius,
+        ) {
+            continue;
+        }
+
+        // Hit: despawn the fireball, emit damage, and grant invincibility.
+        commands.entity(fireball_entity).despawn();
+        damage_events.write(PlayerDamagedEvent {
+            player: player_entity,
+            damage: fireball.damage,
+        });
+        commands.entity(player_entity).insert(InvincibilityTimer {
+            remaining: invincibility_duration,
+        });
+        return; // one hit per frame
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use bevy::ecs::system::RunSystemOnce as _;
+
+    use super::*;
+    use crate::{
+        components::{DragonFireball, Enemy, EnemyAI, Player, PlayerStats},
+        events::PlayerDamagedEvent,
+        types::{AIType, EnemyType},
+    };
+
+    fn build_app() -> App {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        app.add_message::<PlayerDamagedEvent>();
+        app
+    }
+
+    fn spawn_player(app: &mut App, pos: Vec2) -> Entity {
+        app.world_mut()
+            .spawn((
+                Player,
+                PlayerStats::default(),
+                Transform::from_translation(pos.extend(10.0)),
+                CircleCollider { radius: 12.0 },
+            ))
+            .id()
+    }
+
+    fn spawn_dragon(app: &mut App, pos: Vec2) -> Entity {
+        app.world_mut()
+            .spawn((
+                Enemy::from_type(EnemyType::Dragon, 1.0),
+                EnemyAI {
+                    ai_type: AIType::ChasePlayer,
+                    attack_timer: 0.0,
+                    attack_range: 20.0,
+                },
+                Transform::from_translation(pos.extend(5.0)),
+            ))
+            .id()
+    }
+
+    fn advance(app: &mut App, secs: f32) {
+        app.world_mut()
+            .resource_mut::<Time>()
+            .advance_by(Duration::from_secs_f32(secs));
+    }
+
+    // -----------------------------------------------------------------------
+
+    /// Dragon does not fire before the attack interval elapses.
+    #[test]
+    fn dragon_does_not_fire_before_interval() {
+        let mut app = build_app();
+        spawn_player(&mut app, Vec2::new(200.0, 0.0));
+        spawn_dragon(&mut app, Vec2::ZERO);
+
+        advance(&mut app, 0.5); // well below 3.0 s default
+        app.world_mut()
+            .run_system_once(tick_dragon_attack)
+            .expect("tick_dragon_attack should run");
+
+        let mut q = app.world_mut().query::<&DragonFireball>();
+        assert_eq!(
+            q.iter(app.world()).count(),
+            0,
+            "no fireball should fire before the interval"
+        );
+    }
+
+    /// After the attack interval, one fireball is spawned.
+    #[test]
+    fn dragon_fires_after_interval() {
+        let mut app = build_app();
+        spawn_player(&mut app, Vec2::new(200.0, 0.0));
+        let dragon = spawn_dragon(&mut app, Vec2::ZERO);
+
+        // Pre-advance the attack timer to just past the interval.
+        app.world_mut()
+            .entity_mut(dragon)
+            .get_mut::<EnemyAI>()
+            .unwrap()
+            .attack_timer = DEFAULT_DRAGON_ATTACK_INTERVAL - 0.01;
+        advance(&mut app, 0.05); // crosses threshold
+        app.world_mut()
+            .run_system_once(tick_dragon_attack)
+            .expect("tick_dragon_attack should run");
+
+        let mut q = app.world_mut().query::<&DragonFireball>();
+        assert_eq!(
+            q.iter(app.world()).count(),
+            1,
+            "exactly one fireball should be fired"
+        );
+    }
+
+    /// Fireball moves along its velocity each frame.
+    #[test]
+    fn fireball_moves_each_frame() {
+        let mut app = build_app();
+        let fireball = app
+            .world_mut()
+            .spawn((
+                DragonFireball {
+                    damage: 25.0,
+                    velocity: Vec2::new(200.0, 0.0),
+                    lifetime: 6.0,
+                },
+                CircleCollider { radius: 7.0 },
+                Transform::from_translation(Vec3::ZERO),
+            ))
+            .id();
+
+        let dt = 1.0_f32 / 60.0;
+        advance(&mut app, dt);
+        app.world_mut()
+            .run_system_once(move_dragon_fireballs)
+            .expect("move_dragon_fireballs should run");
+
+        let x = app
+            .world()
+            .get::<Transform>(fireball)
+            .unwrap()
+            .translation
+            .x;
+        assert!((x - 200.0 * dt).abs() < 1e-3, "fireball should advance");
+    }
+
+    /// Fireball is despawned when lifetime reaches zero.
+    #[test]
+    fn fireball_despawns_on_lifetime_expiry() {
+        let mut app = build_app();
+        let fireball = app
+            .world_mut()
+            .spawn((
+                DragonFireball {
+                    damage: 25.0,
+                    velocity: Vec2::ZERO,
+                    lifetime: 0.05, // very short
+                },
+                CircleCollider { radius: 7.0 },
+                Transform::default(),
+            ))
+            .id();
+
+        advance(&mut app, 0.1); // past lifetime
+        app.world_mut()
+            .run_system_once(move_dragon_fireballs)
+            .expect("move_dragon_fireballs should run");
+        app.world_mut().flush();
+
+        assert!(
+            app.world().get_entity(fireball).is_err(),
+            "fireball should be despawned after lifetime expires"
+        );
+    }
+
+    /// A fireball overlapping the player deals damage and is despawned.
+    #[test]
+    fn fireball_hitting_player_deals_damage() {
+        let mut app = build_app();
+        let player = spawn_player(&mut app, Vec2::ZERO);
+
+        let fireball = app
+            .world_mut()
+            .spawn((
+                DragonFireball {
+                    damage: 25.0,
+                    velocity: Vec2::ZERO,
+                    lifetime: 6.0,
+                },
+                CircleCollider { radius: 7.0 },
+                Transform::from_translation(Vec3::ZERO),
+            ))
+            .id();
+
+        app.world_mut()
+            .run_system_once(dragon_fireball_player_collision)
+            .expect("collision should run");
+        app.world_mut().flush();
+
+        assert!(
+            app.world().get_entity(fireball).is_err(),
+            "fireball must be despawned on hit"
+        );
+        let messages = app.world().resource::<Messages<PlayerDamagedEvent>>();
+        let mut cursor = messages.get_cursor();
+        let events: Vec<_> = cursor.read(messages).collect();
+        assert_eq!(events.len(), 1, "expected one damage event");
+        assert_eq!(events[0].player, player);
+        assert!((events[0].damage - 25.0).abs() < 1e-6);
+    }
+
+    /// An out-of-range fireball does not deal damage.
+    #[test]
+    fn fireball_far_away_no_damage() {
+        let mut app = build_app();
+        spawn_player(&mut app, Vec2::ZERO);
+        app.world_mut().spawn((
+            DragonFireball {
+                damage: 25.0,
+                velocity: Vec2::ZERO,
+                lifetime: 6.0,
+            },
+            CircleCollider { radius: 7.0 },
+            Transform::from_translation(Vec3::new(500.0, 0.0, 0.0)),
+        ));
+
+        app.world_mut()
+            .run_system_once(dragon_fireball_player_collision)
+            .expect("collision should run");
+
+        let messages = app.world().resource::<Messages<PlayerDamagedEvent>>();
+        let mut cursor = messages.get_cursor();
+        let events: Vec<_> = cursor.read(messages).collect();
+        assert!(events.is_empty(), "no damage when fireball is far away");
+    }
+}

--- a/app/core/src/systems/enemies/mod.rs
+++ b/app/core/src/systems/enemies/mod.rs
@@ -1,6 +1,7 @@
 pub mod ai;
 pub mod cull;
 pub mod difficulty;
+pub mod dragon;
 pub mod medusa;
 pub mod spawn;
 
@@ -15,6 +16,9 @@ impl Plugin for EnemiesPlugin {
         use crate::systems::enemies::ai::move_enemies;
         use crate::systems::enemies::cull::cull_distant_enemies;
         use crate::systems::enemies::difficulty::update_difficulty;
+        use crate::systems::enemies::dragon::{
+            dragon_fireball_player_collision, move_dragon_fireballs, tick_dragon_attack,
+        };
         use crate::systems::enemies::medusa::{
             medusa_projectile_player_collision, move_medusa_projectiles, tick_medusa_attack,
         };
@@ -31,6 +35,11 @@ impl Plugin for EnemiesPlugin {
                 cull_distant_enemies
                     .after(move_enemies)
                     .after(spawn_enemies),
+                tick_dragon_attack.after(move_enemies),
+                move_dragon_fireballs,
+                dragon_fireball_player_collision
+                    .after(move_dragon_fireballs)
+                    .after(enemy_player_collision),
                 tick_medusa_attack.after(move_enemies),
                 move_medusa_projectiles,
                 // Run after enemy_player_collision so that if melee damage fires

--- a/app/core/src/systems/enemies/spawn.rs
+++ b/app/core/src/systems/enemies/spawn.rs
@@ -15,6 +15,7 @@
 //! | Ghost    | 10 min    |
 //! | Demon    | 15 min    |
 //! | Medusa   | 20 min    |
+//! | Dragon   | 25 min    |
 
 use bevy::prelude::*;
 use rand::RngExt;
@@ -52,6 +53,10 @@ const DEFAULT_DEMON_UNLOCK_SECS: f32 = 900.0;
 const DEFAULT_COLLIDER_MEDUSA: f32 = 12.0;
 /// Elapsed seconds before Medusa is added to the spawn table (20 minutes).
 const DEFAULT_MEDUSA_UNLOCK_SECS: f32 = 1200.0;
+/// Collider radius for Dragon enemies (pixels).
+const DEFAULT_COLLIDER_DRAGON: f32 = 20.0;
+/// Elapsed seconds before Dragon is added to the spawn table (25 minutes).
+const DEFAULT_DRAGON_UNLOCK_SECS: f32 = 1500.0;
 /// Window width used to compute off-screen spawn bounds (pixels).
 const DEFAULT_WINDOW_WIDTH: u32 = 1280;
 /// Window height used to compute off-screen spawn bounds (pixels).
@@ -151,6 +156,11 @@ pub fn spawn_enemies(
         .map(|c| c.medusa_unlock_secs)
         .unwrap_or(DEFAULT_MEDUSA_UNLOCK_SECS)
         .max(0.0);
+    let dragon_unlock = enemy_cfg
+        .get()
+        .map(|c| c.dragon_unlock_secs)
+        .unwrap_or(DEFAULT_DRAGON_UNLOCK_SECS)
+        .max(0.0);
 
     // Build the spawn table from independent unlock flags so each enemy type
     // respects only its own threshold, regardless of ordering in the config.
@@ -166,6 +176,9 @@ pub fn spawn_enemies(
     }
     if elapsed >= medusa_unlock {
         table.push(EnemyType::Medusa);
+    }
+    if elapsed >= dragon_unlock {
+        table.push(EnemyType::Dragon);
     }
 
     let mut rng = rand::rng();
@@ -237,6 +250,8 @@ fn enemy_color(enemy_type: EnemyType) -> Color {
         EnemyType::Demon => Color::srgb(0.8, 0.1, 0.05),
         // Stone/snake gray for Medusa.
         EnemyType::Medusa => Color::srgb(0.6, 0.6, 0.5),
+        // Deep orange-red for Dragon.
+        EnemyType::Dragon => Color::srgb(0.9, 0.3, 0.0),
         // Fallback for future types added before they get explicit visuals.
         _ => Color::srgb(0.7, 0.3, 0.3),
     }
@@ -251,6 +266,7 @@ fn fallback_collider_radius(enemy_type: EnemyType) -> f32 {
         EnemyType::Ghost => DEFAULT_COLLIDER_GHOST,
         EnemyType::Demon => DEFAULT_COLLIDER_DEMON,
         EnemyType::Medusa => DEFAULT_COLLIDER_MEDUSA,
+        EnemyType::Dragon => DEFAULT_COLLIDER_DRAGON,
         _ => 10.0,
     }
 }
@@ -822,6 +838,122 @@ mod tests {
             }
         }
         panic!("expected at least one Medusa spawn in 500 attempts to verify KeepDistance AI");
+    }
+
+    /// Dragon stats match the issue spec (HP 150, speed 90, damage 25).
+    #[test]
+    fn dragon_has_correct_base_stats() {
+        use crate::components::Enemy;
+        let e = Enemy::from_type(EnemyType::Dragon, 1.0);
+        assert_eq!(e.max_hp, 150.0, "Dragon base HP must be 150");
+        assert_eq!(e.move_speed, 90.0, "Dragon speed must be 90");
+        assert_eq!(e.damage, 25.0, "Dragon damage must be 25");
+    }
+
+    /// Before 25 min, Dragon must not appear in the spawn table.
+    #[test]
+    fn dragon_does_not_spawn_before_twenty_five_minutes() {
+        use bevy::ecs::system::RunSystemOnce as _;
+        use std::time::Duration;
+
+        let mut dragon_count = 0usize;
+        for _ in 0..200 {
+            let mut app = build_playing_app();
+            app.world_mut().resource_mut::<GameData>().elapsed_time =
+                DEFAULT_DRAGON_UNLOCK_SECS - 1.0;
+            app.world_mut().resource_mut::<EnemySpawner>().spawn_timer =
+                DEFAULT_ENEMY_SPAWN_BASE_INTERVAL + 0.1;
+            app.world_mut()
+                .resource_mut::<Time>()
+                .advance_by(Duration::from_secs_f32(1.0 / 60.0));
+            app.world_mut()
+                .run_system_once(spawn_enemies)
+                .expect("spawn_enemies should run");
+
+            let mut q = app.world_mut().query::<&Enemy>();
+            for e in q.iter(app.world()) {
+                if e.enemy_type == EnemyType::Dragon {
+                    dragon_count += 1;
+                }
+            }
+        }
+        assert_eq!(
+            dragon_count, 0,
+            "Dragon must not spawn before 25 min, but spawned {dragon_count} times in 200 attempts"
+        );
+    }
+
+    /// After 25 min, Dragon should appear in the spawn table.
+    #[test]
+    fn dragon_can_spawn_after_twenty_five_minutes() {
+        use bevy::ecs::system::RunSystemOnce as _;
+        use std::time::Duration;
+
+        let mut dragon_count = 0usize;
+        for _ in 0..500 {
+            let mut app = build_playing_app();
+            app.world_mut().resource_mut::<GameData>().elapsed_time =
+                DEFAULT_DRAGON_UNLOCK_SECS + 1.0;
+            app.world_mut().resource_mut::<EnemySpawner>().spawn_timer =
+                DEFAULT_ENEMY_SPAWN_BASE_INTERVAL + 0.1;
+            app.world_mut()
+                .resource_mut::<Time>()
+                .advance_by(Duration::from_secs_f32(1.0 / 60.0));
+            app.world_mut()
+                .run_system_once(spawn_enemies)
+                .expect("spawn_enemies should run");
+
+            let mut q = app.world_mut().query::<&Enemy>();
+            for e in q.iter(app.world()) {
+                if e.enemy_type == EnemyType::Dragon {
+                    dragon_count += 1;
+                }
+            }
+        }
+        assert!(
+            dragon_count > 0,
+            "Dragon must appear after 25 min (0 spawns in 500 attempts)"
+        );
+    }
+
+    /// Dragon spawned after 25 min must use ChasePlayer AI.
+    #[test]
+    fn dragon_spawns_with_chase_player_ai() {
+        use bevy::ecs::system::RunSystemOnce as _;
+        use std::time::Duration;
+
+        for _ in 0..500 {
+            let mut app = build_playing_app();
+            app.world_mut().resource_mut::<GameData>().elapsed_time =
+                DEFAULT_DRAGON_UNLOCK_SECS + 1.0;
+            app.world_mut().resource_mut::<EnemySpawner>().spawn_timer =
+                DEFAULT_ENEMY_SPAWN_BASE_INTERVAL + 0.1;
+            app.world_mut()
+                .resource_mut::<Time>()
+                .advance_by(Duration::from_secs_f32(1.0 / 60.0));
+            app.world_mut()
+                .run_system_once(spawn_enemies)
+                .expect("spawn_enemies should run");
+            app.world_mut().flush();
+
+            let mut eq = app.world_mut().query::<(&Enemy, &EnemyAI)>();
+            let dragons: Vec<_> = eq
+                .iter(app.world())
+                .filter(|(e, _)| e.enemy_type == EnemyType::Dragon)
+                .collect();
+
+            if !dragons.is_empty() {
+                for (_, ai) in &dragons {
+                    assert_eq!(
+                        ai.ai_type,
+                        AIType::ChasePlayer,
+                        "Dragon must use ChasePlayer AI"
+                    );
+                }
+                return;
+            }
+        }
+        panic!("expected at least one Dragon spawn in 500 attempts to verify ChasePlayer AI");
     }
 
     /// Spawned enemy must carry `Enemy`, `EnemyAI`, and `CircleCollider`.

--- a/app/vampire-survivors/assets/config/enemy.ron
+++ b/app/vampire-survivors/assets/config/enemy.ron
@@ -68,9 +68,9 @@ EnemyConfig(
         collider_radius: 12.0,
     ),
     dragon: (
-        base_hp:         200.0,
-        speed:           80.0,
-        damage:          20.0,
+        base_hp:         150.0,
+        speed:           90.0,
+        damage:          25.0,
         xp_value:        15,
         gold_chance:     0.15,
         collider_radius: 20.0,
@@ -93,6 +93,7 @@ EnemyConfig(
     ghost_unlock_secs:   600.0,
     demon_unlock_secs:   900.0,
     medusa_unlock_secs:  1200.0,
+    dragon_unlock_secs:  1500.0,
     medusa_behavior: (
         keep_min_dist:       150.0,
         keep_max_dist:       250.0,
@@ -100,5 +101,11 @@ EnemyConfig(
         projectile_speed:    180.0,
         projectile_lifetime: 5.0,
         projectile_radius:   5.0,
+    ),
+    dragon_behavior: (
+        attack_interval:  3.0,
+        fireball_speed:   200.0,
+        fireball_lifetime: 6.0,
+        fireball_radius:  7.0,
     ),
 )


### PR DESCRIPTION
## 概要

Issue #53 の Dragon 敵キャラクターを実装します。

- **移動 AI**: `ChasePlayer`（プレイヤーに直進）
- **火球攻撃**: 3 秒ごとにプレイヤー方向へ火球を発射
- **アンロック条件**: 経過時間 25 分以降にスポーンテーブルへ追加
- **ステータス**: HP 150、速度 90 px/s、接触ダメージ 25

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `components/enemy.rs` | `DragonFireball` コンポーネント追加、Dragon 定数を issue 仕様に修正 |
| `config/enemy.rs` | `DragonBehaviorConfig` + `dragon_unlock_secs` + `dragon_behavior` フィールド追加 |
| `systems/enemies/dragon.rs` | `tick_dragon_attack`, `move_dragon_fireballs`, `dragon_fireball_player_collision` + 6 ユニットテスト (新規) |
| `systems/enemies/spawn.rs` | Dragon をスポーンテーブルへ追加、`ChasePlayer` AI で spawn |
| `systems/enemies/mod.rs` | dragon モジュール登録、3 システムを `EnemiesPlugin` に追加 |
| `assets/config/enemy.ron` | Dragon stats 修正、unlock 時刻・behavior パラメータ追加 |

## テスト

- `dragon_has_correct_base_stats` — HP/速度/ダメージ検証
- `dragon_does_not_spawn_before_twenty_five_minutes` — 25 分未満ではスポーンしない
- `dragon_can_spawn_after_twenty_five_minutes` — 25 分以降にスポーンする
- `dragon_spawns_with_chase_player_ai` — `ChasePlayer` AI で生成される
- `dragon_does_not_fire_before_interval` / `dragon_fires_after_interval` — 攻撃タイマー
- `fireball_moves_each_frame` / `fireball_despawns_on_lifetime_expiry` — 弾道挙動
- `fireball_hitting_player_deals_damage` / `fireball_far_away_no_damage` — 衝突判定

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dragons now attack with fireballs that deal damage on contact
  * Dragons spawn at the 25-minute mark with new combat mechanics

* **Balance Changes**
  * Dragon stats rebalanced: HP reduced to 150 (from 200), speed increased to 90 (from 80), damage increased to 25 (from 20)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->