### PR TITLE
feat(enemies): ボス出現タイミングシステムを実装 (issue #55)

### DIFF
--- a/app/core/src/events.rs
+++ b/app/core/src/events.rs
@@ -79,6 +79,16 @@ pub struct PlayerDamagedEvent {
 // Game state events
 // ---------------------------------------------------------------------------
 
+/// Fired when Boss Death spawns at the 30-minute mark.
+///
+/// The [`check_boss_spawn`](crate::systems::enemies::boss_spawn::check_boss_spawn)
+/// system emits this event, sets [`GameData::boss_spawned`] to `true`, and
+/// deactivates [`EnemySpawner`](crate::resources::EnemySpawner) so that
+/// normal enemy spawning stops.  UI systems (e.g. the "BOSS APPROACHING"
+/// warning) listen for this event to notify the player.
+#[derive(Message, Debug, Clone)]
+pub struct BossSpawnedEvent;
+
 /// Fired when the player's HP reaches zero.
 ///
 /// The [`check_player_death`](crate::systems::game_over::check_player_death)

--- a/app/core/src/lib.rs
+++ b/app/core/src/lib.rs
@@ -9,8 +9,8 @@ pub mod types;
 use bevy::prelude::*;
 
 use events::{
-    DamageEnemyEvent, EnemyDiedEvent, GameOverEvent, LevelUpEvent, PlayerDamagedEvent,
-    WeaponFiredEvent,
+    BossSpawnedEvent, DamageEnemyEvent, EnemyDiedEvent, GameOverEvent, LevelUpEvent,
+    PlayerDamagedEvent, WeaponFiredEvent,
 };
 use resources::{
     EnemySpawner, GameData, LevelUpChoices, MetaProgress, PendingUpgradeIndex, SelectedCharacter,
@@ -80,6 +80,7 @@ impl Plugin for GameCorePlugin {
             .add_message::<PlayerDamagedEvent>()
             .add_message::<GameOverEvent>()
             .add_message::<LevelUpEvent>()
+            .add_message::<BossSpawnedEvent>()
             // ---------------------------------------------------------------
             // Per-run reset: fires only when a brand-new run begins.
             // Covers both entry paths — Title → Playing (when CharacterSelect

--- a/app/core/src/systems/enemies/boss_spawn.rs
+++ b/app/core/src/systems/enemies/boss_spawn.rs
@@ -1,0 +1,258 @@
+//! Boss spawn system — triggers Boss Death at the 30-minute mark.
+//!
+//! [`check_boss_spawn`] runs every frame during [`AppState::Playing`].
+//! When `GameData.elapsed_time` first reaches `boss_spawn_time` (default
+//! 1800 s from `game.ron`) it:
+//!
+//! 1. Sets `GameData.boss_spawned = true` to prevent re-entry.
+//! 2. Sets `EnemySpawner.active = false` to stop normal enemy spawning.
+//! 3. Emits a [`BossSpawnedEvent`] for UI and other listeners.
+//! 4. Spawns the Boss Death entity just off-screen to the right of the player.
+
+use bevy::prelude::*;
+
+use crate::{
+    components::{CircleCollider, Enemy, EnemyAI, GameSessionEntity, Player},
+    config::GameParams,
+    events::BossSpawnedEvent,
+    resources::{EnemySpawner, GameData},
+    types::{AIType, EnemyType},
+};
+
+// ---------------------------------------------------------------------------
+// Fallback constants (used when RON config is not yet loaded)
+// ---------------------------------------------------------------------------
+
+/// Boss spawn time in seconds (30 minutes).
+const DEFAULT_BOSS_SPAWN_TIME: f32 = 1800.0;
+/// Collider radius for Boss Death in pixels.
+const DEFAULT_BOSS_COLLIDER: f32 = 40.0;
+/// Horizontal offset from the player when spawning the boss (pixels).
+const BOSS_SPAWN_OFFSET_X: f32 = 700.0;
+
+// ---------------------------------------------------------------------------
+// System
+// ---------------------------------------------------------------------------
+
+/// Checks whether the 30-minute mark has been reached and spawns Boss Death.
+///
+/// This is a no-op once `game_data.boss_spawned` is `true`, so it is safe to
+/// keep registered in `Update` without any per-frame cost after the trigger.
+pub fn check_boss_spawn(
+    mut commands: Commands,
+    mut game_data: ResMut<GameData>,
+    mut enemy_spawner: ResMut<EnemySpawner>,
+    mut boss_events: MessageWriter<BossSpawnedEvent>,
+    game_cfg: GameParams,
+    player_q: Query<&Transform, With<Player>>,
+) {
+    // Already spawned — nothing to do.
+    if game_data.boss_spawned {
+        return;
+    }
+
+    let spawn_time = game_cfg
+        .get()
+        .map(|c| c.boss_spawn_time)
+        .unwrap_or(DEFAULT_BOSS_SPAWN_TIME);
+
+    if game_data.elapsed_time < spawn_time {
+        return;
+    }
+
+    // Mark boss spawned and stop normal enemy spawning.
+    game_data.boss_spawned = true;
+    enemy_spawner.active = false;
+    boss_events.write(BossSpawnedEvent);
+
+    // Spawn just off-screen to the right of the player; fall back to origin.
+    let offset = Vec2::new(BOSS_SPAWN_OFFSET_X, 0.0);
+    let spawn_pos = player_q
+        .single()
+        .map(|t| t.translation.truncate() + offset)
+        .unwrap_or(offset);
+
+    let difficulty = enemy_spawner.difficulty_multiplier.max(1.0);
+    let enemy = Enemy::from_type(EnemyType::BossDeath, difficulty);
+
+    commands.spawn((
+        GameSessionEntity,
+        enemy,
+        EnemyAI {
+            ai_type: AIType::BossMultiPhase,
+            attack_timer: 0.0,
+            attack_range: 300.0,
+        },
+        CircleCollider {
+            radius: DEFAULT_BOSS_COLLIDER,
+        },
+        Sprite {
+            color: Color::srgb(0.3, 0.0, 0.5),
+            custom_size: Some(Vec2::splat(DEFAULT_BOSS_COLLIDER * 2.0)),
+            ..default()
+        },
+        Transform::from_xyz(spawn_pos.x, spawn_pos.y, 5.0),
+    ));
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use bevy::ecs::system::RunSystemOnce as _;
+    use bevy::state::app::StatesPlugin;
+
+    use super::*;
+    use crate::resources::GameData;
+    use crate::states::AppState;
+
+    fn build_app() -> App {
+        let mut app = App::new();
+        app.add_plugins((MinimalPlugins, StatesPlugin));
+        app.init_state::<AppState>();
+        app.insert_resource(GameData::default());
+        app.insert_resource(EnemySpawner::default());
+        app.add_message::<BossSpawnedEvent>();
+        app
+    }
+
+    fn boss_events(app: &App) -> Vec<BossSpawnedEvent> {
+        let messages = app.world().resource::<Messages<BossSpawnedEvent>>();
+        let mut cursor = messages.get_cursor();
+        cursor.read(messages).cloned().collect()
+    }
+
+    /// Before the time threshold is reached, nothing happens.
+    #[test]
+    fn no_spawn_before_time_threshold() {
+        let mut app = build_app();
+        app.world_mut().resource_mut::<GameData>().elapsed_time = DEFAULT_BOSS_SPAWN_TIME - 1.0;
+
+        app.world_mut()
+            .run_system_once(check_boss_spawn)
+            .expect("check_boss_spawn should run");
+
+        assert!(boss_events(&app).is_empty(), "no event before threshold");
+        assert!(
+            !app.world().resource::<GameData>().boss_spawned,
+            "boss_spawned should still be false"
+        );
+        assert!(
+            app.world().resource::<EnemySpawner>().active,
+            "spawner should still be active"
+        );
+    }
+
+    /// When elapsed_time reaches the threshold the boss event fires.
+    #[test]
+    fn spawn_fires_event_at_threshold() {
+        let mut app = build_app();
+        app.world_mut().resource_mut::<GameData>().elapsed_time = DEFAULT_BOSS_SPAWN_TIME;
+
+        app.world_mut()
+            .run_system_once(check_boss_spawn)
+            .expect("check_boss_spawn should run");
+
+        assert_eq!(boss_events(&app).len(), 1, "exactly one BossSpawnedEvent");
+    }
+
+    /// After the boss spawns, `boss_spawned` is true and the spawner is inactive.
+    #[test]
+    fn spawn_sets_boss_spawned_flag_and_disables_spawner() {
+        let mut app = build_app();
+        app.world_mut().resource_mut::<GameData>().elapsed_time = DEFAULT_BOSS_SPAWN_TIME;
+
+        app.world_mut()
+            .run_system_once(check_boss_spawn)
+            .expect("check_boss_spawn should run");
+
+        assert!(
+            app.world().resource::<GameData>().boss_spawned,
+            "boss_spawned must be set to true"
+        );
+        assert!(
+            !app.world().resource::<EnemySpawner>().active,
+            "spawner must be deactivated"
+        );
+    }
+
+    /// Calling the system a second time is a no-op (no double-spawn).
+    #[test]
+    fn no_double_spawn_when_already_spawned() {
+        let mut app = build_app();
+        {
+            let mut gd = app.world_mut().resource_mut::<GameData>();
+            gd.elapsed_time = DEFAULT_BOSS_SPAWN_TIME + 10.0;
+            gd.boss_spawned = true;
+        }
+
+        app.world_mut()
+            .run_system_once(check_boss_spawn)
+            .expect("check_boss_spawn should run");
+
+        assert!(
+            boss_events(&app).is_empty(),
+            "no event when already spawned"
+        );
+    }
+
+    /// A Boss Death entity is spawned in the world.
+    #[test]
+    fn boss_entity_is_spawned() {
+        let mut app = build_app();
+        app.world_mut().resource_mut::<GameData>().elapsed_time = DEFAULT_BOSS_SPAWN_TIME;
+
+        app.world_mut()
+            .run_system_once(check_boss_spawn)
+            .expect("check_boss_spawn should run");
+        app.world_mut().flush();
+
+        let mut q = app
+            .world_mut()
+            .query_filtered::<&Enemy, With<GameSessionEntity>>();
+        let enemies: Vec<_> = q.iter(app.world()).collect();
+        assert_eq!(enemies.len(), 1, "exactly one boss entity expected");
+        assert_eq!(
+            enemies[0].enemy_type,
+            EnemyType::BossDeath,
+            "spawned entity must be BossDeath"
+        );
+    }
+
+    /// Elapsed time exactly at threshold triggers the spawn (boundary check).
+    #[test]
+    fn spawn_triggers_exactly_at_threshold() {
+        let mut app = build_app();
+        app.world_mut().resource_mut::<GameData>().elapsed_time = DEFAULT_BOSS_SPAWN_TIME;
+
+        app.world_mut()
+            .run_system_once(check_boss_spawn)
+            .expect("check_boss_spawn should run");
+
+        assert_eq!(boss_events(&app).len(), 1, "event at exact threshold");
+    }
+
+    /// Advance time via run_system_once to confirm the system is time-driven.
+    #[test]
+    fn timer_advance_triggers_boss_spawn() {
+        let mut app = build_app();
+
+        // Advance to just below threshold — nothing fires.
+        app.world_mut().resource_mut::<GameData>().elapsed_time = DEFAULT_BOSS_SPAWN_TIME - 0.01;
+        app.world_mut()
+            .run_system_once(check_boss_spawn)
+            .expect("run 1");
+        assert!(boss_events(&app).is_empty());
+
+        // Cross the threshold — boss spawns.
+        app.world_mut().resource_mut::<GameData>().elapsed_time = DEFAULT_BOSS_SPAWN_TIME;
+        app.world_mut()
+            .run_system_once(check_boss_spawn)
+            .expect("run 2");
+        assert_eq!(boss_events(&app).len(), 1);
+    }
+}

--- a/app/core/src/systems/enemies/mod.rs
+++ b/app/core/src/systems/enemies/mod.rs
@@ -1,4 +1,5 @@
 pub mod ai;
+pub mod boss_spawn;
 pub mod cull;
 pub mod difficulty;
 pub mod dragon;
@@ -14,6 +15,7 @@ pub struct EnemiesPlugin;
 impl Plugin for EnemiesPlugin {
     fn build(&self, app: &mut App) {
         use crate::systems::enemies::ai::move_enemies;
+        use crate::systems::enemies::boss_spawn::check_boss_spawn;
         use crate::systems::enemies::cull::cull_distant_enemies;
         use crate::systems::enemies::difficulty::update_difficulty;
         use crate::systems::enemies::dragon::{
@@ -31,6 +33,11 @@ impl Plugin for EnemiesPlugin {
             (
                 move_enemies.after(player_movement),
                 update_difficulty.after(update_game_timer),
+                // Boss spawn must run before spawn_enemies so that setting
+                // EnemySpawner.active = false takes effect within the same frame.
+                check_boss_spawn
+                    .after(update_game_timer)
+                    .before(spawn_enemies),
                 spawn_enemies.after(update_difficulty),
                 cull_distant_enemies
                     .after(move_enemies)

--- a/app/ui/src/hud/gameplay/boss_warning.rs
+++ b/app/ui/src/hud/gameplay/boss_warning.rs
@@ -1,0 +1,278 @@
+//! Boss-approaching warning notification.
+//!
+//! Displays a "BOSS APPROACHING" banner at the center of the screen when
+//! [`BossSpawnedEvent`] fires.  The text holds full opacity for
+//! [`DEFAULT_HOLD_SECS`] seconds, then fades to transparent and the entity
+//! is despawned — following the same lifecycle as [`super::evolution_notification`].
+//!
+//! ## Lifecycle
+//!
+//! ```text
+//! BossSpawnedEvent  →  spawn_boss_warning (Update system)  →  spawn Node + Text
+//!                                ↓
+//!                  update_boss_warning (Update system)
+//!                        ticks elapsed, fades alpha, despawns
+//! ```
+
+use bevy::prelude::*;
+use bevy::state::state_scoped::DespawnOnExit;
+use vs_core::events::BossSpawnedEvent;
+use vs_core::states::AppState;
+
+// ---------------------------------------------------------------------------
+// Fallback constants
+// ---------------------------------------------------------------------------
+
+/// Total display duration in seconds (hold + fade).
+const DEFAULT_DISPLAY_DURATION: f32 = 4.0;
+/// Time at which the alpha fade-out begins (seconds).
+const DEFAULT_FADE_START: f32 = 2.0;
+/// Font size for the warning text.
+const DEFAULT_FONT_SIZE: f32 = 52.0;
+/// Vertical position as a percentage of screen height.
+const DEFAULT_TOP_PERCENT: f32 = 35.0;
+/// Warning text color: bright red.
+const DEFAULT_TEXT_COLOR: Color = Color::srgb(1.0, 0.15, 0.15);
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+/// Drives the fade-and-despawn animation of the boss warning overlay.
+///
+/// Placed on the root [`Node`] entity.  [`update_boss_warning`] advances
+/// `elapsed` each frame, updates the text alpha, and despawns the entity once
+/// `elapsed >= duration`.
+#[derive(Component, Debug)]
+pub struct BossWarningNotification {
+    /// Elapsed time since the notification was spawned (seconds).
+    pub elapsed: f32,
+    /// Total lifetime before despawn (seconds).
+    pub duration: f32,
+    /// Time at which the alpha fade-out begins (seconds).
+    pub fade_start: f32,
+    /// Entity holding [`TextColor`]; its alpha is updated each frame.
+    pub text_entity: Entity,
+    /// Base text color (fully opaque); alpha is overridden during fade-out.
+    pub text_color: Color,
+}
+
+// ---------------------------------------------------------------------------
+// Systems
+// ---------------------------------------------------------------------------
+
+/// Spawns a "BOSS APPROACHING" banner when [`BossSpawnedEvent`] fires.
+///
+/// Runs every frame in the `Playing` state; is a no-op until the event
+/// arrives, after which it spawns the overlay entities once.
+pub fn spawn_boss_warning(mut commands: Commands, mut events: MessageReader<BossSpawnedEvent>) {
+    for _ in events.read() {
+        let text_entity = commands
+            .spawn((
+                Text::new("BOSS APPROACHING"),
+                TextFont {
+                    font_size: DEFAULT_FONT_SIZE,
+                    ..default()
+                },
+                TextColor(DEFAULT_TEXT_COLOR),
+                TextLayout::new_with_justify(Justify::Center),
+            ))
+            .id();
+
+        commands
+            .spawn((
+                Node {
+                    position_type: PositionType::Absolute,
+                    width: Val::Percent(100.0),
+                    top: Val::Percent(DEFAULT_TOP_PERCENT),
+                    display: Display::Flex,
+                    justify_content: JustifyContent::Center,
+                    ..default()
+                },
+                BossWarningNotification {
+                    elapsed: 0.0,
+                    duration: DEFAULT_DISPLAY_DURATION,
+                    fade_start: DEFAULT_FADE_START,
+                    text_entity,
+                    text_color: DEFAULT_TEXT_COLOR,
+                },
+                DespawnOnExit(AppState::Playing),
+            ))
+            .add_child(text_entity);
+    }
+}
+
+/// Advances all active [`BossWarningNotification`] animations each frame.
+///
+/// - Ticks `elapsed` by `Δt`.
+/// - Keeps full opacity while `elapsed < fade_start`.
+/// - Fades alpha linearly from 1.0 → 0.0 over the remaining lifetime.
+/// - Despawns the root entity (and its text child) once `elapsed >= duration`.
+pub fn update_boss_warning(
+    mut commands: Commands,
+    time: Res<Time>,
+    mut notif_q: Query<(Entity, &mut BossWarningNotification)>,
+    mut text_q: Query<&mut TextColor>,
+) {
+    let dt = time.delta_secs();
+    for (entity, mut notif) in notif_q.iter_mut() {
+        notif.elapsed += dt;
+
+        if notif.elapsed >= notif.duration {
+            commands.entity(entity).despawn();
+            continue;
+        }
+
+        let alpha = if notif.elapsed < notif.fade_start {
+            1.0_f32
+        } else {
+            let fade_progress =
+                (notif.elapsed - notif.fade_start) / (notif.duration - notif.fade_start);
+            (1.0 - fade_progress).max(0.0)
+        };
+
+        if let Ok(mut text_color) = text_q.get_mut(notif.text_entity) {
+            text_color.0 = notif.text_color.with_alpha(alpha);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use bevy::ecs::system::RunSystemOnce as _;
+
+    use super::*;
+
+    fn build_app() -> App {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        app
+    }
+
+    fn advance(app: &mut App, secs: f32) {
+        app.world_mut()
+            .resource_mut::<Time>()
+            .advance_by(Duration::from_secs_f32(secs));
+    }
+
+    fn spawn_notification(app: &mut App, elapsed: f32) -> Entity {
+        let text_entity = app.world_mut().spawn(TextColor(DEFAULT_TEXT_COLOR)).id();
+        app.world_mut()
+            .spawn(BossWarningNotification {
+                elapsed,
+                duration: DEFAULT_DISPLAY_DURATION,
+                fade_start: DEFAULT_FADE_START,
+                text_entity,
+                text_color: DEFAULT_TEXT_COLOR,
+            })
+            .id()
+    }
+
+    /// Notification is despawned once elapsed reaches the duration.
+    #[test]
+    fn notification_despawns_when_elapsed_reaches_duration() {
+        let mut app = build_app();
+        let entity = spawn_notification(&mut app, DEFAULT_DISPLAY_DURATION - 0.001);
+
+        advance(&mut app, 0.1);
+        app.world_mut()
+            .run_system_once(update_boss_warning)
+            .unwrap();
+        app.world_mut().flush();
+
+        assert!(
+            app.world().get_entity(entity).is_err(),
+            "notification should be despawned when elapsed >= duration"
+        );
+    }
+
+    /// Notification survives before its duration is reached.
+    #[test]
+    fn notification_survives_before_duration() {
+        let mut app = build_app();
+        let entity = spawn_notification(&mut app, 0.0);
+
+        advance(&mut app, 0.1);
+        app.world_mut()
+            .run_system_once(update_boss_warning)
+            .unwrap();
+
+        assert!(
+            app.world().get_entity(entity).is_ok(),
+            "notification should survive before its duration"
+        );
+    }
+
+    /// Alpha is 1.0 while elapsed is before fade_start.
+    #[test]
+    fn alpha_is_full_before_fade_start() {
+        let mut app = build_app();
+        let entity = spawn_notification(&mut app, 0.0);
+        let text_entity = app
+            .world()
+            .get::<BossWarningNotification>(entity)
+            .unwrap()
+            .text_entity;
+
+        advance(&mut app, DEFAULT_FADE_START - 0.1);
+        app.world_mut()
+            .run_system_once(update_boss_warning)
+            .unwrap();
+
+        let color = app.world().get::<TextColor>(text_entity).unwrap().0;
+        let alpha = color.to_srgba().alpha;
+        assert!(
+            (alpha - 1.0).abs() < 1e-4,
+            "alpha should be 1.0 before fade_start, got {alpha}"
+        );
+    }
+
+    /// Alpha decreases after fade_start.
+    #[test]
+    fn alpha_decreases_after_fade_start() {
+        let mut app = build_app();
+        let entity = spawn_notification(&mut app, DEFAULT_FADE_START + 0.1);
+        let text_entity = app
+            .world()
+            .get::<BossWarningNotification>(entity)
+            .unwrap()
+            .text_entity;
+
+        advance(&mut app, 0.01);
+        app.world_mut()
+            .run_system_once(update_boss_warning)
+            .unwrap();
+
+        let color = app.world().get::<TextColor>(text_entity).unwrap().0;
+        let alpha = color.to_srgba().alpha;
+        assert!(
+            alpha < 1.0,
+            "alpha should be less than 1.0 after fade_start, got {alpha}"
+        );
+    }
+
+    /// Elapsed advances by the time delta each frame.
+    #[test]
+    fn elapsed_advances_each_frame() {
+        let mut app = build_app();
+        let entity = spawn_notification(&mut app, 0.0);
+
+        advance(&mut app, 0.5);
+        app.world_mut()
+            .run_system_once(update_boss_warning)
+            .unwrap();
+
+        let notif = app.world().get::<BossWarningNotification>(entity).unwrap();
+        assert!(
+            notif.elapsed >= 0.5 - f32::EPSILON,
+            "elapsed should advance by delta_secs; got {}",
+            notif.elapsed
+        );
+    }
+}

--- a/app/ui/src/hud/gameplay/mod.rs
+++ b/app/ui/src/hud/gameplay/mod.rs
@@ -21,6 +21,7 @@
 //! | [`level`]                 | Level label             | `spawn_level`                 | `update_level_text`               |
 //! | [`evolution_notification`]| Evolution toast         | `on_weapon_evolved` (observer)| `update_evolution_notification`   |
 
+pub mod boss_warning;
 pub mod evolution_notification;
 pub mod hp_bar;
 pub mod level;

--- a/app/ui/src/lib.rs
+++ b/app/ui/src/lib.rs
@@ -70,6 +70,8 @@ impl Plugin for GameUIPlugin {
                     hud::gameplay::timer::update_timer,
                     hud::gameplay::level::update_level_text,
                     hud::gameplay::evolution_notification::update_evolution_notification,
+                    hud::gameplay::boss_warning::spawn_boss_warning,
+                    hud::gameplay::boss_warning::update_boss_warning,
                 )
                     .run_if(in_state(AppState::Playing)),
             )


### PR DESCRIPTION
## 概要

30分（1800秒）経過後にBoss Deathをスポーンするシステムを実装した。ボス出現時に通常の敵スポーンを停止し、`BossSpawnedEvent` を送信する。UI側では「BOSS APPROACHING」警告テキストを4秒間表示してプレイヤーに通知する。

## 変更内容

- `events.rs`: `BossSpawnedEvent` を追加
- `boss_spawn.rs` (新規): `check_boss_spawn` システム — `elapsed_time >= boss_spawn_time` で `boss_spawned = true`、`EnemySpawner.active = false`、ボスエンティティをスポーン
- `enemies/mod.rs`: `check_boss_spawn` を `update_game_timer` 後・`spawn_enemies` 前に登録
- `boss_warning.rs` (新規): `BossSpawnedEvent` を受信し「BOSS APPROACHING」を4秒（2秒保持+2秒フェードアウト）表示
- `lib.rs` / `ui/lib.rs`: `BossSpawnedEvent` 登録、ボス警告システムを `Playing` 状態で登録

## テスト

- [x] ユニットテスト 12件追加（`boss_spawn.rs`: 7件、`boss_warning.rs`: 5件）
- [x] `just fmt` 実行済み
- [x] `just clippy` 実行済み（警告なし）
- [x] `just test` 実行済み（全415テストパス）

Closes #55

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Boss spawns automatically at the 30-minute mark with a centered "BOSS APPROACHING" warning notification
  * Regular enemy spawning is disabled when the boss arrives, marking a new gameplay phase

<!-- end of auto-generated comment: release notes by coderabbit.ai -->