### PR TITLE
feat(enemies): ボスPhase3 AI — 2倍速、5体分身、鎌攻撃（issue #59）

### DIFF
--- a/app/core/src/components/enemy.rs
+++ b/app/core/src/components/enemy.rs
@@ -147,6 +147,21 @@ pub struct DragonFireball {
     pub lifetime: f32,
 }
 
+/// Scythe projectile fired by Boss Death during [`BossPhase::Phase3`].
+///
+/// Moves in a straight line toward the player's position at fire time.
+/// Despawns when [`lifetime`](BossScythe::lifetime) reaches zero or
+/// when it hits the player.
+#[derive(Component, Debug)]
+pub struct BossScythe {
+    /// Contact damage dealt to the player on hit.
+    pub damage: f32,
+    /// Velocity vector (pixels/second).
+    pub velocity: Vec2,
+    /// Remaining lifetime before the projectile despawns (seconds).
+    pub lifetime: f32,
+}
+
 /// Marker component: this enemy phases through other enemy entities.
 ///
 /// Currently informational — no enemy-to-enemy collision is implemented.

--- a/app/core/src/config/game.rs
+++ b/app/core/src/config/game.rs
@@ -52,6 +52,21 @@ pub struct GameConfig {
     pub mini_death_spawn_count: usize,
     /// Radial distance from the boss center when placing Mini Deaths (pixels).
     pub mini_death_spawn_radius: f32,
+    // Boss Phase3 behavior
+    /// Speed multiplier applied to the boss's base move speed in Phase3.
+    pub boss_phase3_speed_multiplier: f32,
+    /// Number of Mini Deaths summoned at the Phase3 transition.
+    pub mini_death_spawn_count_phase3: usize,
+    /// Seconds between scythe projectile shots in Phase3.
+    pub boss_scythe_interval: f32,
+    /// Scythe projectile travel speed in pixels per second.
+    pub boss_scythe_speed: f32,
+    /// Scythe projectile lifetime in seconds before despawn.
+    pub boss_scythe_lifetime: f32,
+    /// Damage dealt to the player on scythe hit.
+    pub boss_scythe_damage: f32,
+    /// Scythe projectile collider radius in pixels.
+    pub boss_scythe_radius: f32,
 }
 
 /// Resource holding the handle to the loaded game configuration.
@@ -143,6 +158,13 @@ GameConfig(
     boss_phase2_speed_multiplier: 1.5,
     mini_death_spawn_count: 3,
     mini_death_spawn_radius: 80.0,
+    boss_phase3_speed_multiplier: 2.0,
+    mini_death_spawn_count_phase3: 5,
+    boss_scythe_interval: 3.0,
+    boss_scythe_speed: 250.0,
+    boss_scythe_lifetime: 8.0,
+    boss_scythe_damage: 80.0,
+    boss_scythe_radius: 15.0,
 )
 "#;
         let config: GameConfig = ron::de::from_str(ron_data).unwrap();
@@ -166,5 +188,12 @@ GameConfig(
         assert_eq!(config.boss_phase2_speed_multiplier, 1.5);
         assert_eq!(config.mini_death_spawn_count, 3);
         assert_eq!(config.mini_death_spawn_radius, 80.0);
+        assert_eq!(config.boss_phase3_speed_multiplier, 2.0);
+        assert_eq!(config.mini_death_spawn_count_phase3, 5);
+        assert_eq!(config.boss_scythe_interval, 3.0);
+        assert_eq!(config.boss_scythe_speed, 250.0);
+        assert_eq!(config.boss_scythe_lifetime, 8.0);
+        assert_eq!(config.boss_scythe_damage, 80.0);
+        assert_eq!(config.boss_scythe_radius, 15.0);
     }
 }

--- a/app/core/src/systems/enemies/boss_ai.rs
+++ b/app/core/src/systems/enemies/boss_ai.rs
@@ -1,17 +1,18 @@
 //! Boss AI systems — movement and phase-transition logic.
 //!
-//! | Phase     | HP threshold | Behavior                                     |
-//! |-----------|--------------|----------------------------------------------|
-//! | `Phase1`  | 100% – 60%   | Chase player at base speed (30 px/s)         |
-//! | `Phase2`  | ≤ 60%        | Chase at 1.5× speed, 3 Mini Deaths summoned  |
-//! | `Phase3`  | ≤ 30%        | Implemented in future issue                  |
+//! | Phase     | HP threshold | Behavior                                                 |
+//! |-----------|--------------|----------------------------------------------------------|
+//! | `Phase1`  | 100% – 60%   | Chase player at base speed (30 px/s)                     |
+//! | `Phase2`  | ≤ 60%        | Chase at 1.5× speed, 3 Mini Deaths summoned              |
+//! | `Phase3`  | ≤ 30%        | Chase at 2× speed, 5 Mini Deaths, scythe every 3 s       |
 //!
 //! ## System ordering
 //!
 //! All systems run each frame in [`AppState::Playing`]:
 //!
-//! - [`move_boss_phase1`] / [`move_boss_phase2`] run after `player_movement`
-//!   so the boss always aims at the player's updated position.
+//! - [`move_boss_phase1`] / [`move_boss_phase2`] / [`move_boss_phase3`] run
+//!   after `player_movement` so the boss always aims at the player's updated
+//!   position.
 //! - [`check_boss_phase_transition`] runs after the move systems; once it
 //!   flips the phase, the corresponding move system stops and the next starts.
 
@@ -29,10 +30,16 @@ use crate::{
 
 /// HP fraction (inclusive) below which Phase1 transitions to Phase2.
 const DEFAULT_PHASE2_HP_THRESHOLD: f32 = 0.6;
+/// HP fraction (inclusive) below which Phase2 transitions to Phase3.
+const DEFAULT_PHASE3_HP_THRESHOLD: f32 = 0.3;
 /// Speed multiplier applied to the boss's base `move_speed` in Phase2.
 const DEFAULT_PHASE2_SPEED_MULTIPLIER: f32 = 1.5;
+/// Speed multiplier applied to the boss's base `move_speed` in Phase3.
+const DEFAULT_PHASE3_SPEED_MULTIPLIER: f32 = 2.0;
 /// Number of Mini Deaths summoned when the boss enters Phase2.
 const DEFAULT_MINI_DEATH_SPAWN_COUNT: usize = 3;
+/// Number of Mini Deaths summoned when the boss enters Phase3.
+const DEFAULT_MINI_DEATH_SPAWN_COUNT_PHASE3: usize = 5;
 /// Radial offset from the boss center when placing each Mini Death (pixels).
 const DEFAULT_MINI_DEATH_SPAWN_RADIUS: f32 = 80.0;
 /// Collider radius for Mini Death entities when config is not loaded (pixels).
@@ -99,17 +106,48 @@ pub fn move_boss_phase2(
     }
 }
 
+/// Moves Boss Death toward the player while in [`BossPhase::Phase3`].
+///
+/// Applies `boss_phase3_speed_multiplier` (default 2.0×) to `enemy.move_speed`,
+/// raising the effective speed from 30 to 60 px/s.  The system is a no-op when
+/// no player entity exists or when the boss is in any phase other than Phase3.
+pub fn move_boss_phase3(
+    time: Res<Time>,
+    player_q: Query<&Transform, With<Player>>,
+    mut boss_q: Query<(&Enemy, &mut Transform, &BossPhase), Without<Player>>,
+    game_cfg: GameParams,
+) {
+    let Ok(player_tf) = player_q.single() else {
+        return;
+    };
+    let player_pos = player_tf.translation.truncate();
+    let dt = time.delta_secs();
+    let multiplier = game_cfg
+        .get()
+        .map(|c| c.boss_phase3_speed_multiplier)
+        .unwrap_or(DEFAULT_PHASE3_SPEED_MULTIPLIER);
+
+    for (enemy, mut boss_tf, phase) in boss_q.iter_mut() {
+        if *phase != BossPhase::Phase3 {
+            continue;
+        }
+        let boss_pos = boss_tf.translation.truncate();
+        let direction = (player_pos - boss_pos).normalize_or_zero();
+        boss_tf.translation += (direction * enemy.move_speed * multiplier * dt).extend(0.0);
+    }
+}
+
 /// Monitors boss HP and advances phase when thresholds are crossed (inclusive).
 ///
-/// - Phase1 → Phase2 at HP ≤ 60%: increases speed and summons Mini Deaths.
-/// - Phase2 → Phase3 at HP ≤ 30%: detected but no Phase3 behavior yet —
-///   the boss remains in Phase2 until Phase3 is implemented in a future issue.
+/// - Phase1 → Phase2 at HP ≤ 60%: increases speed and summons 3 Mini Deaths.
+/// - Phase2 → Phase3 at HP ≤ 30%: further increases speed, summons 5 Mini Deaths,
+///   and resets the scythe attack timer so the first shot fires after a full interval.
 ///
 /// Runs every frame; each transition fires exactly once (guarded by the
 /// current phase check).
 pub fn check_boss_phase_transition(
     mut commands: Commands,
-    mut boss_q: Query<(&Enemy, &mut BossPhase, &Transform)>,
+    mut boss_q: Query<(&Enemy, &mut BossPhase, &Transform, &mut EnemyAI)>,
     game_cfg: GameParams,
     enemy_cfg: EnemyParams,
 ) {
@@ -117,19 +155,45 @@ pub fn check_boss_phase_transition(
         .get()
         .map(|c| c.boss_phase2_hp_threshold)
         .unwrap_or(DEFAULT_PHASE2_HP_THRESHOLD);
+    let phase3_threshold = game_cfg
+        .get()
+        .map(|c| c.boss_phase3_hp_threshold)
+        .unwrap_or(DEFAULT_PHASE3_HP_THRESHOLD);
+    let spawn_radius = game_cfg
+        .get()
+        .map(|c| c.mini_death_spawn_radius)
+        .unwrap_or(DEFAULT_MINI_DEATH_SPAWN_RADIUS);
+    let phase2_count = game_cfg
+        .get()
+        .map(|c| c.mini_death_spawn_count)
+        .unwrap_or(DEFAULT_MINI_DEATH_SPAWN_COUNT);
+    let phase3_count = game_cfg
+        .get()
+        .map(|c| c.mini_death_spawn_count_phase3)
+        .unwrap_or(DEFAULT_MINI_DEATH_SPAWN_COUNT_PHASE3);
 
-    for (enemy, mut phase, boss_tf) in boss_q.iter_mut() {
+    for (enemy, mut phase, boss_tf, mut ai) in boss_q.iter_mut() {
         if *phase == BossPhase::Phase1 && enemy.current_hp <= enemy.max_hp * phase2_threshold {
             *phase = BossPhase::Phase2;
             spawn_mini_deaths(
                 &mut commands,
                 boss_tf.translation.truncate(),
-                game_cfg.get(),
+                phase2_count,
+                spawn_radius,
+                enemy_cfg.get(),
+            );
+        } else if *phase == BossPhase::Phase2 && enemy.current_hp <= enemy.max_hp * phase3_threshold
+        {
+            *phase = BossPhase::Phase3;
+            ai.attack_timer = 0.0;
+            spawn_mini_deaths(
+                &mut commands,
+                boss_tf.translation.truncate(),
+                phase3_count,
+                spawn_radius,
                 enemy_cfg.get(),
             );
         }
-        // Phase3 behavior is implemented in a future issue.
-        // The boss deliberately stays in Phase2 to avoid freezing.
     }
 }
 
@@ -139,22 +203,16 @@ pub fn check_boss_phase_transition(
 
 /// Spawns Mini Death entities evenly distributed around `boss_pos`.
 ///
-/// Spawn count and radius are read from [`GameConfig`]; falls back to
-/// `DEFAULT_MINI_DEATH_SPAWN_COUNT` / `DEFAULT_MINI_DEATH_SPAWN_RADIUS`.
+/// `spawn_count` and `spawn_radius` are provided by the caller (computed from
+/// [`GameConfig`] or fallback defaults depending on the phase).
 /// Enemy stats are read from [`EnemyConfig`] when available.
 fn spawn_mini_deaths(
     commands: &mut Commands,
     boss_pos: Vec2,
-    game_cfg: Option<&crate::config::GameConfig>,
+    spawn_count: usize,
+    spawn_radius: f32,
     enemy_cfg: Option<&EnemyConfig>,
 ) {
-    let spawn_count = game_cfg
-        .map(|c| c.mini_death_spawn_count)
-        .unwrap_or(DEFAULT_MINI_DEATH_SPAWN_COUNT);
-    let spawn_radius = game_cfg
-        .map(|c| c.mini_death_spawn_radius)
-        .unwrap_or(DEFAULT_MINI_DEATH_SPAWN_RADIUS);
-
     let (enemy, collider_radius) = match enemy_cfg {
         Some(c) => {
             let stats = c.stats_for(EnemyType::MiniDeath);
@@ -211,7 +269,7 @@ mod tests {
     use super::*;
     use crate::{
         components::{Enemy, Player},
-        types::{BossPhase, EnemyType},
+        types::{AIType, BossPhase, EnemyType},
     };
 
     fn build_app() -> App {
@@ -234,6 +292,11 @@ mod tests {
             .spawn((
                 enemy,
                 BossPhase::Phase1,
+                EnemyAI {
+                    ai_type: AIType::BossMultiPhase,
+                    attack_timer: 0.0,
+                    attack_range: 300.0,
+                },
                 Transform::from_xyz(pos.x, pos.y, 0.0),
             ))
             .id()
@@ -296,6 +359,21 @@ mod tests {
 
         let x = app.world().get::<Transform>(boss).unwrap().translation.x;
         assert_eq!(x, -500.0, "Phase2 boss must not be moved by Phase1 system");
+    }
+
+    /// Phase3 boss is not moved by move_boss_phase1.
+    #[test]
+    fn phase3_boss_not_moved_by_phase1_system() {
+        let mut app = build_app();
+        let boss = spawn_boss(&mut app, 500.0, 5000.0, Vec2::new(-500.0, 0.0));
+        app.world_mut().entity_mut(boss).insert(BossPhase::Phase3);
+        spawn_player(&mut app, Vec2::ZERO);
+
+        advance(&mut app, 1.0 / 60.0);
+        app.world_mut().run_system_once(move_boss_phase1).unwrap();
+
+        let x = app.world().get::<Transform>(boss).unwrap().translation.x;
+        assert_eq!(x, -500.0, "Phase3 boss must not be moved by Phase1 system");
     }
 
     /// No player → boss stays stationary.
@@ -379,6 +457,90 @@ mod tests {
         assert_eq!(x, -500.0, "Phase1 boss must not be moved by Phase2 system");
     }
 
+    /// Phase3 boss is not moved by move_boss_phase2.
+    #[test]
+    fn phase3_boss_not_moved_by_phase2_system() {
+        let mut app = build_app();
+        let boss = spawn_boss(&mut app, 500.0, 5000.0, Vec2::new(-500.0, 0.0));
+        app.world_mut().entity_mut(boss).insert(BossPhase::Phase3);
+        spawn_player(&mut app, Vec2::ZERO);
+
+        advance(&mut app, 1.0 / 60.0);
+        app.world_mut().run_system_once(move_boss_phase2).unwrap();
+
+        let x = app.world().get::<Transform>(boss).unwrap().translation.x;
+        assert_eq!(x, -500.0, "Phase3 boss must not be moved by Phase2 system");
+    }
+
+    // -----------------------------------------------------------------------
+    // move_boss_phase3
+    // -----------------------------------------------------------------------
+
+    /// Phase3 boss moves toward the player faster than Phase2.
+    #[test]
+    fn phase3_boss_moves_faster_than_phase2() {
+        let mut app2 = build_app();
+        let boss2 = spawn_boss(&mut app2, 500.0, 5000.0, Vec2::new(-10000.0, 0.0));
+        app2.world_mut().entity_mut(boss2).insert(BossPhase::Phase2);
+        spawn_player(&mut app2, Vec2::ZERO);
+
+        let mut app3 = build_app();
+        let boss3 = spawn_boss(&mut app3, 500.0, 5000.0, Vec2::new(-10000.0, 0.0));
+        app3.world_mut().entity_mut(boss3).insert(BossPhase::Phase3);
+        spawn_player(&mut app3, Vec2::ZERO);
+
+        let dt = 1.0_f32;
+        advance(&mut app2, dt);
+        advance(&mut app3, dt);
+
+        app2.world_mut().run_system_once(move_boss_phase2).unwrap();
+        app3.world_mut().run_system_once(move_boss_phase3).unwrap();
+
+        let x2 = app2.world().get::<Transform>(boss2).unwrap().translation.x;
+        let x3 = app3.world().get::<Transform>(boss3).unwrap().translation.x;
+        assert!(
+            x3 > x2,
+            "Phase3 boss should move farther than Phase2 in the same time; x2={x2} x3={x3}"
+        );
+    }
+
+    /// Phase3 boss applies the 2.0× speed multiplier (fallback — no config loaded).
+    #[test]
+    fn phase3_boss_applies_speed_multiplier() {
+        let mut app = build_app();
+        let boss = spawn_boss(&mut app, 500.0, 5000.0, Vec2::new(-10000.0, 0.0));
+        app.world_mut().entity_mut(boss).insert(BossPhase::Phase3);
+        spawn_player(&mut app, Vec2::ZERO);
+
+        let dt = 1.0_f32;
+        advance(&mut app, dt);
+        app.world_mut().run_system_once(move_boss_phase3).unwrap();
+
+        let x = app.world().get::<Transform>(boss).unwrap().translation.x;
+        let base_speed = Enemy::from_type(EnemyType::BossDeath, 1.0).move_speed;
+        // Contract: Phase3 speed multiplier is 2.0.
+        let expected = base_speed * 2.0 * dt;
+        let moved = x - (-10000.0);
+        assert!(
+            (moved - expected).abs() < 0.1,
+            "Phase3 speed should be base × 2.0 = {expected} px; moved {moved}"
+        );
+    }
+
+    /// Phase1 boss is not moved by move_boss_phase3.
+    #[test]
+    fn phase1_boss_not_moved_by_phase3_system() {
+        let mut app = build_app();
+        let boss = spawn_boss(&mut app, 5000.0, 5000.0, Vec2::new(-500.0, 0.0));
+        spawn_player(&mut app, Vec2::ZERO);
+
+        advance(&mut app, 1.0 / 60.0);
+        app.world_mut().run_system_once(move_boss_phase3).unwrap();
+
+        let x = app.world().get::<Transform>(boss).unwrap().translation.x;
+        assert_eq!(x, -500.0, "Phase1 boss must not be moved by Phase3 system");
+    }
+
     // -----------------------------------------------------------------------
     // check_boss_phase_transition
     // -----------------------------------------------------------------------
@@ -434,6 +596,42 @@ mod tests {
         );
     }
 
+    /// Phase2 transitions to Phase3 at exactly 30% HP (inclusive threshold).
+    #[test]
+    fn exact_threshold_triggers_phase3() {
+        let mut app = build_app();
+        let boss = spawn_boss(&mut app, 1500.0, 5000.0, Vec2::ZERO); // exactly 30%
+        app.world_mut().entity_mut(boss).insert(BossPhase::Phase2);
+
+        app.world_mut()
+            .run_system_once(check_boss_phase_transition)
+            .unwrap();
+
+        assert_eq!(
+            *app.world().get::<BossPhase>(boss).unwrap(),
+            BossPhase::Phase3,
+            "exactly 30% HP should trigger Phase3 (threshold is inclusive)"
+        );
+    }
+
+    /// Phase2 transitions to Phase3 when HP drops below 30%.
+    #[test]
+    fn transitions_to_phase3_below_threshold() {
+        let mut app = build_app();
+        let boss = spawn_boss(&mut app, 1499.0, 5000.0, Vec2::ZERO); // 29.98%
+        app.world_mut().entity_mut(boss).insert(BossPhase::Phase2);
+
+        app.world_mut()
+            .run_system_once(check_boss_phase_transition)
+            .unwrap();
+
+        assert_eq!(
+            *app.world().get::<BossPhase>(boss).unwrap(),
+            BossPhase::Phase3,
+            "boss should transition to Phase3 below 30% HP"
+        );
+    }
+
     /// Phase2 is not reverted to Phase1 (one-way transition).
     #[test]
     fn phase2_is_not_reverted() {
@@ -478,6 +676,57 @@ mod tests {
         );
     }
 
+    /// Five Mini Deaths are spawned when Phase2 → Phase3 transition fires.
+    /// Contract: spawn count is 5.
+    #[test]
+    fn phase3_transition_spawns_five_mini_deaths() {
+        let mut app = build_app();
+        let boss = spawn_boss(&mut app, 1499.0, 5000.0, Vec2::ZERO); // 29.98%
+        app.world_mut().entity_mut(boss).insert(BossPhase::Phase2);
+
+        app.world_mut()
+            .run_system_once(check_boss_phase_transition)
+            .unwrap();
+        app.world_mut().flush();
+
+        let mut q = app
+            .world_mut()
+            .query_filtered::<&Enemy, With<GameSessionEntity>>();
+        let mini_deaths: Vec<_> = q
+            .iter(app.world())
+            .filter(|e| e.enemy_type == EnemyType::MiniDeath)
+            .collect();
+        assert_eq!(
+            mini_deaths.len(),
+            5, // contract: exactly 5 Mini Deaths spawn at Phase3
+            "exactly 5 Mini Deaths should spawn at Phase3 transition"
+        );
+    }
+
+    /// Phase3 entry resets the boss attack timer to 0.
+    #[test]
+    fn phase3_entry_resets_attack_timer() {
+        let mut app = build_app();
+        let boss = spawn_boss(&mut app, 1499.0, 5000.0, Vec2::ZERO);
+        app.world_mut().entity_mut(boss).insert(BossPhase::Phase2);
+        // Simulate accumulated attack timer.
+        app.world_mut()
+            .entity_mut(boss)
+            .get_mut::<EnemyAI>()
+            .unwrap()
+            .attack_timer = 2.5;
+
+        app.world_mut()
+            .run_system_once(check_boss_phase_transition)
+            .unwrap();
+
+        let ai = app.world().get::<EnemyAI>(boss).unwrap();
+        assert_eq!(
+            ai.attack_timer, 0.0,
+            "attack_timer must be reset to 0 on Phase3 entry"
+        );
+    }
+
     /// Mini Deaths spawn evenly distributed around the boss at 80 px radius.
     /// Contract: spawn radius is 80.0 px.
     #[test]
@@ -515,7 +764,7 @@ mod tests {
         let mut app = build_app();
         let boss = spawn_boss(&mut app, 2999.0, 5000.0, Vec2::ZERO);
 
-        // First call: Phase1 → Phase2, spawns Mini Deaths.
+        // First call: Phase1 → Phase2, spawns 3 Mini Deaths.
         app.world_mut()
             .run_system_once(check_boss_phase_transition)
             .unwrap();
@@ -539,24 +788,6 @@ mod tests {
             mini_deaths.len(),
             3,
             "Mini Deaths must only spawn once at Phase2 transition"
-        );
-    }
-
-    /// Boss stays in Phase2 when HP drops below 30% (Phase3 not yet implemented).
-    #[test]
-    fn boss_stays_phase2_below_phase3_threshold() {
-        let mut app = build_app();
-        let boss = spawn_boss(&mut app, 1499.0, 5000.0, Vec2::ZERO); // 29.98%
-        app.world_mut().entity_mut(boss).insert(BossPhase::Phase2);
-
-        app.world_mut()
-            .run_system_once(check_boss_phase_transition)
-            .unwrap();
-
-        assert_eq!(
-            *app.world().get::<BossPhase>(boss).unwrap(),
-            BossPhase::Phase2,
-            "boss must remain Phase2 until Phase3 behavior is implemented"
         );
     }
 }

--- a/app/core/src/systems/enemies/boss_scythe.rs
+++ b/app/core/src/systems/enemies/boss_scythe.rs
@@ -1,0 +1,456 @@
+//! Boss scythe systems — Phase3 ranged projectile attack.
+//!
+//! Three systems handle the boss's Phase3 scythe behavior:
+//!
+//! - [`tick_boss_scythe_attack`] — advances `EnemyAI::attack_timer`; fires a
+//!   [`BossScythe`] toward the player when the attack interval elapses.
+//! - [`move_boss_scythes`] — translates every active scythe along its velocity
+//!   vector and despawns it when its lifetime expires.
+//! - [`boss_scythe_player_collision`] — checks each scythe against the player's
+//!   collider and emits a [`PlayerDamagedEvent`] on contact.
+
+use bevy::prelude::*;
+
+use crate::{
+    components::{
+        BossScythe, CircleCollider, Enemy, EnemyAI, GameSessionEntity, InvincibilityTimer, Player,
+        PlayerStats,
+    },
+    config::{GameParams, PlayerParams},
+    events::PlayerDamagedEvent,
+    systems::collision::check_circle_collision,
+    types::{BossPhase, EnemyType},
+};
+
+// ---------------------------------------------------------------------------
+// Fallback constants (used when RON config is not yet loaded)
+// ---------------------------------------------------------------------------
+
+/// Seconds between Boss Phase3 scythe shots.
+const DEFAULT_BOSS_SCYTHE_INTERVAL: f32 = 3.0;
+/// Scythe travel speed in pixels/second.
+const DEFAULT_BOSS_SCYTHE_SPEED: f32 = 250.0;
+/// Scythe lifetime in seconds before despawn.
+const DEFAULT_BOSS_SCYTHE_LIFETIME: f32 = 8.0;
+/// Damage dealt to the player on scythe contact.
+const DEFAULT_BOSS_SCYTHE_DAMAGE: f32 = 80.0;
+/// Scythe collider radius in pixels.
+pub(crate) const DEFAULT_BOSS_SCYTHE_RADIUS: f32 = 15.0;
+/// Invincibility duration granted to the player after a scythe hit (seconds).
+const DEFAULT_SCYTHE_INVINCIBILITY: f32 = 0.5;
+
+// ---------------------------------------------------------------------------
+// Systems
+// ---------------------------------------------------------------------------
+
+/// Ticks `EnemyAI::attack_timer` for Boss Death in Phase3 and fires a
+/// [`BossScythe`] toward the player whenever the attack interval elapses.
+///
+/// Only entities with [`BossPhase::Phase3`] and [`EnemyType::BossDeath`] are
+/// affected.  The system is a no-op when no player entity exists.
+pub fn tick_boss_scythe_attack(
+    mut commands: Commands,
+    time: Res<Time>,
+    player_q: Query<&Transform, With<Player>>,
+    mut boss_q: Query<(&Transform, &Enemy, &mut EnemyAI, &BossPhase)>,
+    game_cfg: GameParams,
+) {
+    let Ok(player_tf) = player_q.single() else {
+        return;
+    };
+    let player_pos = player_tf.translation.truncate();
+
+    let scythe_interval = game_cfg
+        .get()
+        .map(|c| c.boss_scythe_interval)
+        .unwrap_or(DEFAULT_BOSS_SCYTHE_INTERVAL)
+        .max(0.1);
+    let scythe_speed = game_cfg
+        .get()
+        .map(|c| c.boss_scythe_speed)
+        .unwrap_or(DEFAULT_BOSS_SCYTHE_SPEED)
+        .max(1.0);
+    let scythe_lifetime = game_cfg
+        .get()
+        .map(|c| c.boss_scythe_lifetime)
+        .unwrap_or(DEFAULT_BOSS_SCYTHE_LIFETIME)
+        .max(0.1);
+    let scythe_damage = game_cfg
+        .get()
+        .map(|c| c.boss_scythe_damage)
+        .unwrap_or(DEFAULT_BOSS_SCYTHE_DAMAGE);
+    let scythe_radius = game_cfg
+        .get()
+        .map(|c| c.boss_scythe_radius)
+        .unwrap_or(DEFAULT_BOSS_SCYTHE_RADIUS);
+
+    let dt = time.delta_secs();
+
+    for (boss_tf, enemy, mut ai, phase) in boss_q.iter_mut() {
+        if *phase != BossPhase::Phase3 || enemy.enemy_type != EnemyType::BossDeath {
+            continue;
+        }
+
+        ai.attack_timer += dt;
+        if ai.attack_timer < scythe_interval {
+            continue;
+        }
+        ai.attack_timer = 0.0;
+
+        let origin = boss_tf.translation.truncate();
+        let direction = (player_pos - origin).normalize_or_zero();
+        if direction == Vec2::ZERO {
+            continue; // player is exactly on boss — skip
+        }
+
+        commands.spawn((
+            BossScythe {
+                damage: scythe_damage,
+                velocity: direction * scythe_speed,
+                lifetime: scythe_lifetime,
+            },
+            CircleCollider {
+                radius: scythe_radius,
+            },
+            Sprite {
+                color: Color::srgb(0.8, 0.0, 0.8),
+                custom_size: Some(Vec2::splat(scythe_radius * 2.0)),
+                ..default()
+            },
+            Transform::from_translation(origin.extend(4.0)),
+            GameSessionEntity,
+        ));
+    }
+}
+
+/// Advances every [`BossScythe`] along its velocity vector and despawns
+/// those whose lifetime has expired.
+pub fn move_boss_scythes(
+    mut commands: Commands,
+    time: Res<Time>,
+    mut scythe_q: Query<(Entity, &mut Transform, &mut BossScythe)>,
+) {
+    let dt = time.delta_secs();
+    for (entity, mut tf, mut scythe) in scythe_q.iter_mut() {
+        tf.translation += (scythe.velocity * dt).extend(0.0);
+        scythe.lifetime -= dt;
+        if scythe.lifetime <= 0.0 {
+            commands.entity(entity).despawn();
+        }
+    }
+}
+
+/// Checks every active [`BossScythe`] against the player's circle collider.
+/// On contact the scythe is despawned and a [`PlayerDamagedEvent`] is emitted.
+/// Respects the player's [`InvincibilityTimer`].
+#[allow(clippy::type_complexity)]
+pub fn boss_scythe_player_collision(
+    mut commands: Commands,
+    player_q: Query<
+        (Entity, &Transform, &CircleCollider, &PlayerStats),
+        (With<Player>, Without<InvincibilityTimer>),
+    >,
+    scythe_q: Query<(Entity, &Transform, &CircleCollider, &BossScythe)>,
+    player_cfg: PlayerParams,
+    mut damage_events: MessageWriter<PlayerDamagedEvent>,
+) {
+    let Ok((player_entity, player_tf, player_collider, _)) = player_q.single() else {
+        return;
+    };
+    let player_pos = player_tf.translation.truncate();
+
+    let invincibility_duration = player_cfg
+        .get()
+        .map(|c| c.invincibility_time)
+        .unwrap_or(DEFAULT_SCYTHE_INVINCIBILITY);
+
+    for (scythe_entity, scythe_tf, scythe_collider, scythe) in scythe_q.iter() {
+        let scythe_pos = scythe_tf.translation.truncate();
+        if !check_circle_collision(
+            player_pos,
+            player_collider.radius,
+            scythe_pos,
+            scythe_collider.radius,
+        ) {
+            continue;
+        }
+
+        // Hit: despawn the scythe, emit damage, and grant invincibility.
+        commands.entity(scythe_entity).despawn();
+        damage_events.write(PlayerDamagedEvent {
+            player: player_entity,
+            damage: scythe.damage,
+        });
+        commands.entity(player_entity).insert(InvincibilityTimer {
+            remaining: invincibility_duration,
+        });
+        return; // one hit per frame
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use bevy::ecs::system::RunSystemOnce as _;
+
+    use super::*;
+    use crate::{
+        components::{BossScythe, Enemy, EnemyAI, Player, PlayerStats},
+        events::PlayerDamagedEvent,
+        types::{AIType, BossPhase, EnemyType},
+    };
+
+    fn build_app() -> App {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        app.add_message::<PlayerDamagedEvent>();
+        app
+    }
+
+    fn spawn_player(app: &mut App, pos: Vec2) -> Entity {
+        app.world_mut()
+            .spawn((
+                Player,
+                PlayerStats::default(),
+                Transform::from_translation(pos.extend(10.0)),
+                CircleCollider { radius: 12.0 },
+            ))
+            .id()
+    }
+
+    fn spawn_boss_phase3(app: &mut App, pos: Vec2) -> Entity {
+        app.world_mut()
+            .spawn((
+                Enemy::from_type(EnemyType::BossDeath, 1.0),
+                BossPhase::Phase3,
+                EnemyAI {
+                    ai_type: AIType::BossMultiPhase,
+                    attack_timer: 0.0,
+                    attack_range: 300.0,
+                },
+                Transform::from_translation(pos.extend(5.0)),
+            ))
+            .id()
+    }
+
+    fn advance(app: &mut App, secs: f32) {
+        app.world_mut()
+            .resource_mut::<Time>()
+            .advance_by(Duration::from_secs_f32(secs));
+    }
+
+    // -----------------------------------------------------------------------
+    // tick_boss_scythe_attack
+    // -----------------------------------------------------------------------
+
+    /// Boss does not fire before the attack interval elapses.
+    #[test]
+    fn boss_does_not_fire_scythe_before_interval() {
+        let mut app = build_app();
+        spawn_player(&mut app, Vec2::new(200.0, 0.0));
+        spawn_boss_phase3(&mut app, Vec2::ZERO);
+
+        advance(&mut app, 0.5); // well below 3.0 s default
+        app.world_mut()
+            .run_system_once(tick_boss_scythe_attack)
+            .expect("tick_boss_scythe_attack should run");
+
+        let mut q = app.world_mut().query::<&BossScythe>();
+        assert_eq!(
+            q.iter(app.world()).count(),
+            0,
+            "no scythe should fire before the interval"
+        );
+    }
+
+    /// After the attack interval, one scythe is spawned.
+    #[test]
+    fn boss_fires_scythe_after_interval() {
+        let mut app = build_app();
+        spawn_player(&mut app, Vec2::new(200.0, 0.0));
+        let boss = spawn_boss_phase3(&mut app, Vec2::ZERO);
+
+        // Pre-advance the attack timer to just past the interval.
+        app.world_mut()
+            .entity_mut(boss)
+            .get_mut::<EnemyAI>()
+            .unwrap()
+            .attack_timer = DEFAULT_BOSS_SCYTHE_INTERVAL - 0.01;
+        advance(&mut app, 0.05); // crosses threshold
+        app.world_mut()
+            .run_system_once(tick_boss_scythe_attack)
+            .expect("tick_boss_scythe_attack should run");
+
+        let mut q = app.world_mut().query::<&BossScythe>();
+        assert_eq!(
+            q.iter(app.world()).count(),
+            1,
+            "exactly one scythe should be fired"
+        );
+    }
+
+    /// Boss in Phase1 does not fire scythes.
+    #[test]
+    fn phase1_boss_does_not_fire_scythe() {
+        let mut app = build_app();
+        spawn_player(&mut app, Vec2::new(200.0, 0.0));
+        let boss = app
+            .world_mut()
+            .spawn((
+                Enemy::from_type(EnemyType::BossDeath, 1.0),
+                BossPhase::Phase1,
+                EnemyAI {
+                    ai_type: AIType::BossMultiPhase,
+                    attack_timer: DEFAULT_BOSS_SCYTHE_INTERVAL + 1.0, // past interval
+                    attack_range: 300.0,
+                },
+                Transform::from_translation(Vec3::ZERO),
+            ))
+            .id();
+
+        advance(&mut app, 0.05);
+        app.world_mut()
+            .run_system_once(tick_boss_scythe_attack)
+            .expect("tick_boss_scythe_attack should run");
+
+        // Phase1 boss should not fire scythes even if timer is past interval.
+        // (The system skips non-Phase3 entities.)
+        let _ = boss;
+        let mut q = app.world_mut().query::<&BossScythe>();
+        assert_eq!(
+            q.iter(app.world()).count(),
+            0,
+            "Phase1 boss must not fire scythes"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // move_boss_scythes
+    // -----------------------------------------------------------------------
+
+    /// Scythe moves along its velocity each frame.
+    #[test]
+    fn scythe_moves_each_frame() {
+        let mut app = build_app();
+        let scythe = app
+            .world_mut()
+            .spawn((
+                BossScythe {
+                    damage: 80.0,
+                    velocity: Vec2::new(250.0, 0.0),
+                    lifetime: 8.0,
+                },
+                CircleCollider { radius: 15.0 },
+                Transform::from_translation(Vec3::ZERO),
+            ))
+            .id();
+
+        let dt = 1.0_f32 / 60.0;
+        advance(&mut app, dt);
+        app.world_mut()
+            .run_system_once(move_boss_scythes)
+            .expect("move_boss_scythes should run");
+
+        let x = app.world().get::<Transform>(scythe).unwrap().translation.x;
+        assert!((x - 250.0 * dt).abs() < 1e-3, "scythe should advance");
+    }
+
+    /// Scythe is despawned when lifetime reaches zero.
+    #[test]
+    fn scythe_despawns_on_lifetime_expiry() {
+        let mut app = build_app();
+        let scythe = app
+            .world_mut()
+            .spawn((
+                BossScythe {
+                    damage: 80.0,
+                    velocity: Vec2::ZERO,
+                    lifetime: 0.05, // very short
+                },
+                CircleCollider { radius: 15.0 },
+                Transform::default(),
+            ))
+            .id();
+
+        advance(&mut app, 0.1); // past lifetime
+        app.world_mut()
+            .run_system_once(move_boss_scythes)
+            .expect("move_boss_scythes should run");
+        app.world_mut().flush();
+
+        assert!(
+            app.world().get_entity(scythe).is_err(),
+            "scythe should be despawned after lifetime expires"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // boss_scythe_player_collision
+    // -----------------------------------------------------------------------
+
+    /// A scythe overlapping the player deals damage and is despawned.
+    #[test]
+    fn scythe_hitting_player_deals_damage() {
+        let mut app = build_app();
+        let player = spawn_player(&mut app, Vec2::ZERO);
+
+        let scythe = app
+            .world_mut()
+            .spawn((
+                BossScythe {
+                    damage: 80.0,
+                    velocity: Vec2::ZERO,
+                    lifetime: 8.0,
+                },
+                CircleCollider { radius: 15.0 },
+                Transform::from_translation(Vec3::ZERO),
+            ))
+            .id();
+
+        app.world_mut()
+            .run_system_once(boss_scythe_player_collision)
+            .expect("collision should run");
+        app.world_mut().flush();
+
+        assert!(
+            app.world().get_entity(scythe).is_err(),
+            "scythe must be despawned on hit"
+        );
+        let messages = app.world().resource::<Messages<PlayerDamagedEvent>>();
+        let mut cursor = messages.get_cursor();
+        let events: Vec<_> = cursor.read(messages).collect();
+        assert_eq!(events.len(), 1, "expected one damage event");
+        assert_eq!(events[0].player, player);
+        assert!((events[0].damage - 80.0).abs() < 1e-6);
+    }
+
+    /// An out-of-range scythe does not deal damage.
+    #[test]
+    fn scythe_far_away_no_damage() {
+        let mut app = build_app();
+        spawn_player(&mut app, Vec2::ZERO);
+        app.world_mut().spawn((
+            BossScythe {
+                damage: 80.0,
+                velocity: Vec2::ZERO,
+                lifetime: 8.0,
+            },
+            CircleCollider { radius: 15.0 },
+            Transform::from_translation(Vec3::new(500.0, 0.0, 0.0)),
+        ));
+
+        app.world_mut()
+            .run_system_once(boss_scythe_player_collision)
+            .expect("collision should run");
+
+        let messages = app.world().resource::<Messages<PlayerDamagedEvent>>();
+        let mut cursor = messages.get_cursor();
+        let events: Vec<_> = cursor.read(messages).collect();
+        assert!(events.is_empty(), "no damage when scythe is far away");
+    }
+}

--- a/app/core/src/systems/enemies/mod.rs
+++ b/app/core/src/systems/enemies/mod.rs
@@ -1,5 +1,6 @@
 pub mod ai;
 pub mod boss_ai;
+pub mod boss_scythe;
 pub mod boss_spawn;
 pub mod cull;
 pub mod difficulty;
@@ -17,7 +18,10 @@ impl Plugin for EnemiesPlugin {
     fn build(&self, app: &mut App) {
         use crate::systems::enemies::ai::move_enemies;
         use crate::systems::enemies::boss_ai::{
-            check_boss_phase_transition, move_boss_phase1, move_boss_phase2,
+            check_boss_phase_transition, move_boss_phase1, move_boss_phase2, move_boss_phase3,
+        };
+        use crate::systems::enemies::boss_scythe::{
+            boss_scythe_player_collision, move_boss_scythes, tick_boss_scythe_attack,
         };
         use crate::systems::enemies::boss_spawn::check_boss_spawn;
         use crate::systems::enemies::cull::cull_distant_enemies;
@@ -38,9 +42,16 @@ impl Plugin for EnemiesPlugin {
                 move_enemies.after(player_movement),
                 move_boss_phase1.after(player_movement),
                 move_boss_phase2.after(player_movement),
+                move_boss_phase3.after(player_movement),
                 check_boss_phase_transition
                     .after(move_boss_phase1)
-                    .after(move_boss_phase2),
+                    .after(move_boss_phase2)
+                    .after(move_boss_phase3),
+                tick_boss_scythe_attack.after(move_boss_phase3),
+                move_boss_scythes,
+                boss_scythe_player_collision
+                    .after(move_boss_scythes)
+                    .after(enemy_player_collision),
                 update_difficulty.after(update_game_timer),
                 // Boss spawn must run before spawn_enemies so that setting
                 // EnemySpawner.active = false takes effect within the same frame.

--- a/app/vampire-survivors/assets/config/game.ron
+++ b/app/vampire-survivors/assets/config/game.ron
@@ -51,4 +51,12 @@ GameConfig(
     boss_phase2_speed_multiplier:  1.5,   // Phase2 move speed = base × 1.5
     mini_death_spawn_count:        3,     // Mini Deaths spawned at Phase2 transition
     mini_death_spawn_radius:       80.0,  // Radial offset from boss center (pixels)
+    // Boss Phase3 behavior
+    boss_phase3_speed_multiplier:  2.0,   // Phase3 move speed = base × 2.0
+    mini_death_spawn_count_phase3: 5,     // Mini Deaths spawned at Phase3 transition
+    boss_scythe_interval:          3.0,   // Seconds between scythe shots
+    boss_scythe_speed:             250.0, // Scythe travel speed (pixels/second)
+    boss_scythe_lifetime:          8.0,   // Scythe lifetime before despawn (seconds)
+    boss_scythe_damage:            80.0,  // Damage dealt on scythe hit
+    boss_scythe_radius:            15.0,  // Scythe collider radius (pixels)
 )


### PR DESCRIPTION
## 概要

ボスDeath のPhase3 AI を実装しました。HP 30%以下でPhase3に移行し、移動速度2倍化・Mini Death 5体召喚・3秒ごとの鎌投射体攻撃が発動します。

## 変更内容

- **`move_boss_phase3`** を追加: Phase3中はbase speed × 2.0 (60 px/s) でプレイヤーを追尾
- **`check_boss_phase_transition`** にPhase2→Phase3検出を追加: HP ≤ 30%でPhase3移行、Mini Death 5体を召喚、`EnemyAI::attack_timer` をリセット
- **`boss_scythe.rs`** を新規作成: `tick_boss_scythe_attack`（3秒間隔）、`move_boss_scythes`、`boss_scythe_player_collision` の3システム
- **`BossScythe`** コンポーネントを `components/enemy.rs` に追加
- Phase3パラメータを `GameConfig` / `game.ron` に外部化（speed_multiplier, scythe間隔/速度/寿命/ダメージ/半径など）
- `spawn_mini_deaths` をリファクタリング: カウントと半径を呼び出し元から明示的に受け取る形に変更

## テスト

- [x] Phase3移行・移動・鎌攻撃のユニットテストを追加（`boss_ai.rs` + `boss_scythe.rs`）
- [x] `just fmt && just clippy && just test` 実行済み（全テスト通過）
- [x] ゲーム内動作は最終フェーズで確認予定

Closes #59

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced Boss Phase 3 with enhanced movement and a new scythe attack pattern. The boss spawns projectiles at configured intervals, adding a new challenge to late-game encounters. Scythes despawn after their lifetime expires or upon player contact, triggering damage and a brief invincibility period.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->