### PR TITLE
feat(ui): ポーズ画面の実装 (#65)

### DIFF
--- a/app/ui/src/components.rs
+++ b/app/ui/src/components.rs
@@ -61,6 +61,8 @@ pub enum ButtonAction {
     /// that was selected.  Gameplay systems that apply upgrades read this
     /// index when re-entering [`AppState::Playing`].
     SelectUpgrade(usize),
+    /// Resume gameplay from the pause screen — transitions Paused → Playing.
+    ResumeGame,
 }
 
 // ---------------------------------------------------------------------------
@@ -143,6 +145,9 @@ fn apply_action(
             if let Some(p) = pending {
                 p.0 = Some(index);
             }
+            next_state.set(AppState::Playing);
+        }
+        ButtonAction::ResumeGame => {
             next_state.set(AppState::Playing);
         }
     }

--- a/app/ui/src/config/mod.rs
+++ b/app/ui/src/config/mod.rs
@@ -24,6 +24,7 @@
 
 pub mod hud;
 pub mod level_up;
+pub mod pause;
 pub mod styles;
 pub mod victory;
 
@@ -42,6 +43,9 @@ pub use hud::{
 };
 pub use level_up::{
     LevelUpScreenConfig, LevelUpScreenConfigHandle, LevelUpScreenParams, hot_reload_level_up_screen,
+};
+pub use pause::{
+    PauseScreenConfig, PauseScreenConfigHandle, PauseScreenParams, hot_reload_pause_screen,
 };
 pub use styles::{
     SrgbColor, SrgbaColor, TitleHeadingText, TitleScreenBg, UiStyleConfig, UiStyleConfigHandle,
@@ -95,6 +99,7 @@ macro_rules! ron_asset_loader {
 // Screen config loaders
 ron_asset_loader!(UiStyleConfigLoader, UiStyleConfig);
 ron_asset_loader!(LevelUpScreenConfigLoader, LevelUpScreenConfig);
+ron_asset_loader!(PauseScreenConfigLoader, PauseScreenConfig);
 ron_asset_loader!(VictoryScreenConfigLoader, VictoryScreenConfig);
 
 // HUD config loaders
@@ -134,6 +139,8 @@ impl Plugin for UiConfigPlugin {
             .register_asset_loader(UiStyleConfigLoader)
             .init_asset::<LevelUpScreenConfig>()
             .register_asset_loader(LevelUpScreenConfigLoader)
+            .init_asset::<PauseScreenConfig>()
+            .register_asset_loader(PauseScreenConfigLoader)
             .init_asset::<VictoryScreenConfig>()
             .register_asset_loader(VictoryScreenConfigLoader);
 
@@ -173,6 +180,8 @@ impl Plugin for UiConfigPlugin {
         let style_handle: Handle<UiStyleConfig> = asset_server.load("config/ui/styles.ron");
         let level_up_handle: Handle<LevelUpScreenConfig> =
             asset_server.load("config/ui/screen/level_up.ron");
+        let pause_handle: Handle<PauseScreenConfig> =
+            asset_server.load("config/ui/screen/pause.ron");
         let victory_handle: Handle<VictoryScreenConfig> =
             asset_server.load("config/ui/screen/victory.ron");
 
@@ -208,6 +217,7 @@ impl Plugin for UiConfigPlugin {
 
         app.insert_resource(UiStyleConfigHandle(style_handle))
             .insert_resource(LevelUpScreenConfigHandle(level_up_handle))
+            .insert_resource(PauseScreenConfigHandle(pause_handle))
             .insert_resource(VictoryScreenConfigHandle(victory_handle))
             .insert_resource(ScreenHeadingHudConfigHandle(screen_heading_handle))
             .insert_resource(MenuButtonHudConfigHandle(menu_button_handle))
@@ -225,6 +235,7 @@ impl Plugin for UiConfigPlugin {
 
         app.add_systems(Update, hot_reload_ui_style)
             .add_systems(Update, hot_reload_level_up_screen)
+            .add_systems(Update, hot_reload_pause_screen)
             .add_systems(Update, hot_reload_victory_screen)
             .add_systems(
                 Update,

--- a/app/ui/src/config/pause.rs
+++ b/app/ui/src/config/pause.rs
@@ -1,0 +1,102 @@
+//! Pause screen configuration.
+//!
+//! Loaded from `assets/config/ui/screen/pause.ron`.
+//! Controls the visual appearance of the pause overlay.
+
+use bevy::ecs::system::SystemParam;
+use bevy::prelude::*;
+use serde::Deserialize;
+
+use super::{SrgbColor, SrgbaColor};
+
+// ---------------------------------------------------------------------------
+// Config asset
+// ---------------------------------------------------------------------------
+
+/// Pause screen style config loaded from `config/ui/screen/pause.ron`.
+///
+/// The pause overlay is positioned absolutely over the game scene, so
+/// `overlay_color` should carry a meaningful alpha value.
+#[derive(Asset, TypePath, Deserialize, Debug, Clone)]
+pub struct PauseScreenConfig {
+    /// Semi-transparent overlay background color (supports alpha).
+    pub overlay_color: SrgbaColor,
+    /// "PAUSED" / "ポーズ" heading text color.
+    pub heading_color: SrgbColor,
+}
+
+/// Resource holding the handle to the loaded [`PauseScreenConfig`].
+#[derive(Resource)]
+pub struct PauseScreenConfigHandle(pub Handle<PauseScreenConfig>);
+
+// ---------------------------------------------------------------------------
+// SystemParam bundle
+// ---------------------------------------------------------------------------
+
+/// SystemParam bundle for accessing [`PauseScreenConfig`].
+///
+/// Returns `None` while the asset is still loading or when
+/// [`super::UiConfigPlugin`] has not been registered (e.g. in unit tests).
+/// Call `.get()` to obtain `Option<&PauseScreenConfig>`.
+#[derive(SystemParam)]
+pub struct PauseScreenParams<'w> {
+    handle: Option<Res<'w, PauseScreenConfigHandle>>,
+    assets: Option<Res<'w, Assets<PauseScreenConfig>>>,
+}
+
+impl<'w> PauseScreenParams<'w> {
+    /// Returns the currently loaded [`PauseScreenConfig`], or `None`.
+    pub fn get(&self) -> Option<&PauseScreenConfig> {
+        self.handle
+            .as_ref()
+            .and_then(|h| self.assets.as_ref().and_then(|a| a.get(&h.0)))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Hot-reload system
+// ---------------------------------------------------------------------------
+
+/// Logs when `config/ui/screen/pause.ron` is loaded or hot-reloaded.
+pub fn hot_reload_pause_screen(mut events: MessageReader<AssetEvent<PauseScreenConfig>>) {
+    for event in events.read() {
+        match event {
+            AssetEvent::Added { .. } => {
+                info!("✅ Pause screen config loaded");
+            }
+            AssetEvent::Modified { .. } => {
+                info!("🔥 Pause screen config hot-reloaded");
+            }
+            AssetEvent::Removed { .. } => {
+                warn!("⚠️ Pause screen config removed");
+            }
+            _ => {}
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pause_screen_config_deserialization() {
+        let ron_data = r#"
+PauseScreenConfig(
+    overlay_color: (r: 0.02, g: 0.02, b: 0.06, a: 0.88),
+    heading_color: (r: 1.0, g: 0.85, b: 0.20),
+)
+"#;
+        let cfg: PauseScreenConfig = ron::de::from_str(ron_data).expect("RON parse must succeed");
+
+        assert!(
+            (cfg.overlay_color.a - 0.88).abs() < 1e-6,
+            "alpha must be 0.88"
+        );
+        assert!((cfg.heading_color.r - 1.0).abs() < 1e-6);
+    }
+}

--- a/app/ui/src/lib.rs
+++ b/app/ui/src/lib.rs
@@ -76,6 +76,16 @@ impl Plugin for GameUIPlugin {
                 OnEnter(AppState::Victory),
                 screens::victory::setup_victory_screen,
             )
+            // Pause screen
+            .add_systems(
+                OnEnter(AppState::Paused),
+                screens::pause::setup_pause_screen,
+            )
+            .add_systems(
+                Update,
+                screens::pause::toggle_pause
+                    .run_if(in_state(AppState::Playing).or(in_state(AppState::Paused))),
+            )
             // Level-up card selection overlay.
             // Must run after generate_level_up_choices so LevelUpChoices is
             // already populated when the UI reads it.

--- a/app/ui/src/screens/mod.rs
+++ b/app/ui/src/screens/mod.rs
@@ -4,6 +4,7 @@ pub mod character_select;
 pub mod game_over;
 pub mod level_up;
 pub mod meta_shop;
+pub mod pause;
 pub mod settings;
 pub mod title;
 pub mod victory;

--- a/app/ui/src/screens/pause.rs
+++ b/app/ui/src/screens/pause.rs
@@ -1,0 +1,314 @@
+//! Pause screen — shown when the player presses ESC during gameplay.
+//!
+//! The overlay is positioned absolutely so it sits on top of the game scene
+//! without destroying HUD or gameplay entities.  All entities are tagged with
+//! [`DespawnOnExit`]`(`[`AppState::Paused`]`)` so Bevy automatically
+//! despawns them when the state transitions away.
+//!
+//! Systems:
+//! - [`setup_pause_screen`]: spawns the overlay when entering [`AppState::Paused`]
+//! - [`toggle_pause`]: handles ESC key to switch between Playing and Paused
+
+use bevy::prelude::*;
+use bevy::state::state_scoped::DespawnOnExit;
+use vs_core::resources::GameSettings;
+use vs_core::states::AppState;
+
+use crate::components::ButtonAction;
+use crate::config::{MenuButtonHudParams, PauseScreenParams, ScreenHeadingHudParams};
+use crate::hud::menu_button::spawn_large_menu_button;
+use crate::hud::screen_heading::spawn_screen_heading;
+use crate::i18n::{font_for_lang, t};
+
+// ---------------------------------------------------------------------------
+// Fallback constants
+// ---------------------------------------------------------------------------
+
+const DEFAULT_OVERLAY_COLOR: Color = Color::srgba(0.02, 0.02, 0.06, 0.88);
+const DEFAULT_HEADING_COLOR: Color = Color::srgb(1.0, 0.85, 0.20);
+
+// ---------------------------------------------------------------------------
+// Marker components
+// ---------------------------------------------------------------------------
+
+/// Marks the root overlay node of the pause screen.
+#[derive(Component)]
+pub struct PauseScreenOverlay;
+
+// ---------------------------------------------------------------------------
+// Systems
+// ---------------------------------------------------------------------------
+
+/// Spawns the pause overlay when entering [`AppState::Paused`].
+pub fn setup_pause_screen(
+    mut commands: Commands,
+    pause_cfg: PauseScreenParams,
+    heading_cfg: ScreenHeadingHudParams,
+    btn_cfg: MenuButtonHudParams,
+    asset_server: Option<Res<AssetServer>>,
+    settings: Option<Res<GameSettings>>,
+) {
+    let lang = settings.as_deref().map(|s| s.language).unwrap_or_default();
+    let font: Handle<Font> = asset_server
+        .map(|s| s.load(font_for_lang(lang)))
+        .unwrap_or_default();
+
+    let overlay_color = pause_cfg
+        .get()
+        .map(|c| {
+            Color::srgba(
+                c.overlay_color.r,
+                c.overlay_color.g,
+                c.overlay_color.b,
+                c.overlay_color.a,
+            )
+        })
+        .unwrap_or(DEFAULT_OVERLAY_COLOR);
+    let heading_color = pause_cfg
+        .get()
+        .map(|c| Color::from(&c.heading_color))
+        .unwrap_or(DEFAULT_HEADING_COLOR);
+
+    commands
+        .spawn((
+            Node {
+                position_type: PositionType::Absolute,
+                width: Val::Percent(100.0),
+                height: Val::Percent(100.0),
+                flex_direction: FlexDirection::Column,
+                justify_content: JustifyContent::Center,
+                align_items: AlignItems::Center,
+                ..default()
+            },
+            BackgroundColor(overlay_color),
+            ZIndex(10),
+            DespawnOnExit(AppState::Paused),
+            PauseScreenOverlay,
+        ))
+        .with_children(|parent| {
+            spawn_screen_heading(
+                parent,
+                t("pause_title", lang),
+                heading_color,
+                heading_cfg.get(),
+                font.clone(),
+            );
+
+            spawn_large_menu_button(
+                parent,
+                t("btn_resume", lang),
+                ButtonAction::ResumeGame,
+                btn_cfg.get(),
+                font.clone(),
+                Some("btn_resume"),
+            );
+
+            spawn_large_menu_button(
+                parent,
+                t("btn_to_title", lang),
+                ButtonAction::GoToTitle,
+                btn_cfg.get(),
+                font.clone(),
+                Some("btn_to_title"),
+            );
+        });
+}
+
+/// Toggles between [`AppState::Playing`] and [`AppState::Paused`] on ESC.
+pub fn toggle_pause(
+    keys: Res<ButtonInput<KeyCode>>,
+    state: Res<State<AppState>>,
+    mut next_state: ResMut<NextState<AppState>>,
+) {
+    if keys.just_pressed(KeyCode::Escape) {
+        match state.get() {
+            AppState::Playing => next_state.set(AppState::Paused),
+            AppState::Paused => next_state.set(AppState::Playing),
+            _ => {}
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use bevy::state::app::StatesPlugin;
+
+    use super::*;
+    use crate::components::MenuButton;
+    use crate::hud::screen_heading::ScreenHeadingHud;
+
+    fn build_app() -> App {
+        let mut app = App::new();
+        app.add_plugins((MinimalPlugins, StatesPlugin));
+        app.init_state::<AppState>();
+        app
+    }
+
+    fn enter_paused(app: &mut App) {
+        // Default state is Title; go to Playing first, then Paused.
+        app.world_mut()
+            .resource_mut::<NextState<AppState>>()
+            .set(AppState::Playing);
+        app.update();
+        app.world_mut()
+            .resource_mut::<NextState<AppState>>()
+            .set(AppState::Paused);
+        app.update();
+        app.update();
+    }
+
+    #[test]
+    fn setup_pause_screen_spawns_overlay() {
+        let mut app = build_app();
+        app.add_systems(OnEnter(AppState::Paused), setup_pause_screen);
+        enter_paused(&mut app);
+
+        let mut q = app
+            .world_mut()
+            .query_filtered::<Entity, With<PauseScreenOverlay>>();
+        assert_eq!(
+            q.iter(app.world()).count(),
+            1,
+            "exactly one PauseScreenOverlay expected"
+        );
+    }
+
+    #[test]
+    fn setup_pause_screen_has_two_buttons() {
+        let mut app = build_app();
+        app.add_systems(OnEnter(AppState::Paused), setup_pause_screen);
+        enter_paused(&mut app);
+
+        let mut q = app.world_mut().query_filtered::<Entity, With<Button>>();
+        assert_eq!(
+            q.iter(app.world()).count(),
+            2,
+            "pause screen should have exactly two buttons"
+        );
+    }
+
+    #[test]
+    fn pause_screen_has_resume_and_title_buttons() {
+        let mut app = build_app();
+        app.add_systems(OnEnter(AppState::Paused), setup_pause_screen);
+        enter_paused(&mut app);
+
+        let mut q = app.world_mut().query::<&MenuButton>();
+        let actions: Vec<ButtonAction> = q.iter(app.world()).map(|b| b.action).collect();
+        assert!(
+            actions.contains(&ButtonAction::ResumeGame),
+            "pause screen must have a ResumeGame button"
+        );
+        assert!(
+            actions.contains(&ButtonAction::GoToTitle),
+            "pause screen must have a GoToTitle button"
+        );
+    }
+
+    #[test]
+    fn pause_screen_has_heading() {
+        let mut app = build_app();
+        app.add_systems(OnEnter(AppState::Paused), setup_pause_screen);
+        enter_paused(&mut app);
+
+        let mut q = app
+            .world_mut()
+            .query_filtered::<Entity, With<ScreenHeadingHud>>();
+        assert_eq!(
+            q.iter(app.world()).count(),
+            1,
+            "exactly one ScreenHeadingHud expected"
+        );
+    }
+
+    #[test]
+    fn pause_screen_despawns_on_exit() {
+        let mut app = build_app();
+        app.add_systems(OnEnter(AppState::Paused), setup_pause_screen);
+        enter_paused(&mut app);
+
+        {
+            let mut q = app
+                .world_mut()
+                .query_filtered::<Entity, With<PauseScreenOverlay>>();
+            assert_eq!(q.iter(app.world()).count(), 1);
+        }
+
+        app.world_mut()
+            .resource_mut::<NextState<AppState>>()
+            .set(AppState::Playing);
+        app.update();
+        app.update();
+
+        let mut q = app
+            .world_mut()
+            .query_filtered::<Entity, With<PauseScreenOverlay>>();
+        assert_eq!(
+            q.iter(app.world()).count(),
+            0,
+            "pause overlay must despawn after leaving Paused state"
+        );
+    }
+
+    #[test]
+    fn toggle_pause_playing_to_paused() {
+        use bevy::ecs::system::RunSystemOnce as _;
+        use bevy::input::InputPlugin;
+        let mut app = build_app();
+        app.add_plugins(InputPlugin);
+
+        // Start in Playing state.
+        app.world_mut()
+            .resource_mut::<NextState<AppState>>()
+            .set(AppState::Playing);
+        app.update();
+
+        // Press ESC and run toggle_pause directly (bypasses PreUpdate clear).
+        app.world_mut()
+            .resource_mut::<ButtonInput<KeyCode>>()
+            .press(KeyCode::Escape);
+        app.world_mut().run_system_once(toggle_pause).unwrap();
+        app.update(); // apply state transition
+
+        assert_eq!(
+            *app.world().resource::<State<AppState>>(),
+            AppState::Paused,
+            "ESC in Playing should transition to Paused"
+        );
+    }
+
+    #[test]
+    fn toggle_pause_paused_to_playing() {
+        use bevy::ecs::system::RunSystemOnce as _;
+        use bevy::input::InputPlugin;
+        let mut app = build_app();
+        app.add_plugins(InputPlugin);
+
+        // Start in Paused state.
+        app.world_mut()
+            .resource_mut::<NextState<AppState>>()
+            .set(AppState::Playing);
+        app.update();
+        app.world_mut()
+            .resource_mut::<NextState<AppState>>()
+            .set(AppState::Paused);
+        app.update();
+
+        // Press ESC and run toggle_pause directly (bypasses PreUpdate clear).
+        app.world_mut()
+            .resource_mut::<ButtonInput<KeyCode>>()
+            .press(KeyCode::Escape);
+        app.world_mut().run_system_once(toggle_pause).unwrap();
+        app.update(); // apply state transition
+
+        assert_eq!(
+            *app.world().resource::<State<AppState>>(),
+            AppState::Playing,
+            "ESC in Paused should transition to Playing"
+        );
+    }
+}

--- a/app/vampire-survivors/assets/config/ui/screen/pause.ron
+++ b/app/vampire-survivors/assets/config/ui/screen/pause.ron
@@ -1,0 +1,13 @@
+// Pause screen configuration.
+// Controls the visual appearance of the pause overlay.
+//
+// Hot-reload enabled: Edit this file while the game is running to see changes instantly!
+//
+// Parameters:
+// - overlay_color:  Semi-transparent overlay background color (RGBA, 0.0-1.0)
+// - heading_color:  "PAUSED" heading text color (RGB, 0.0-1.0)
+
+PauseScreenConfig(
+    overlay_color: (r: 0.02, g: 0.02, b: 0.06, a: 0.88),
+    heading_color: (r: 1.0,  g: 0.85, b: 0.20),
+)


### PR DESCRIPTION
## 概要

ESCキーでゲームを一時停止・再開できるポーズ画面を実装しました。

## 対応内容

- `ButtonAction::ResumeGame` バリアントを追加し、`apply_action` でポーズ→プレイ遷移を処理
- `PauseScreenConfig` RON設定ファイルを追加（オーバーレイ色・見出し色をホットリロード対応）
- `setup_pause_screen` システムでゲーム画面上に絶対位置オーバーレイを生成
- `toggle_pause` システムでESCキー入力を検知し Playing ↔ Paused を切り替え
- `UiConfigPlugin` にポーズ設定のローダー・ハンドル・ホットリロードを追加

## 機能解説

| 要素 | 詳細 |
|------|------|
| ESCキー | Playing→Paused / Paused→Playing を切り替え |
| オーバーレイ | `PositionType::Absolute` でゲーム画面上に重ねて表示 |
| 「再開」ボタン | `ButtonAction::ResumeGame` → `AppState::Playing` |
| 「タイトルへ」ボタン | `ButtonAction::GoToTitle` → `AppState::Title` |
| i18n | `pause_title`・`btn_resume` キーを使用（既存のキーを流用） |
| 後処理 | `DespawnOnExit(AppState::Paused)` で自動クリーンアップ |

## 影響範囲

| クレート | モジュール/ファイル | 変更内容 |
|---------|-------------------|---------|
| `vs-ui` | `components.rs` | `ResumeGame` バリアント追加 |
| `vs-ui` | `config/pause.rs` | 新規：`PauseScreenConfig` |
| `vs-ui` | `config/mod.rs` | ポーズ設定のローダー・ハンドル・ホットリロード登録 |
| `vs-ui` | `screens/pause.rs` | 新規：`setup_pause_screen` / `toggle_pause` |
| `vs-ui` | `screens/mod.rs` | `pause` モジュール追加 |
| `vs-ui` | `lib.rs` | `OnEnter(Paused)` / `toggle_pause` の配線 |
| `vs` | `assets/config/ui/screen/pause.ron` | 新規：RON設定ファイル |

## テスト計画

- [x] `just fmt` — フォーマット確認
- [x] `just clippy` — 警告なし
- [x] `just test` — 全619テスト通過（ポーズ画面7件追加）
  - `setup_pause_screen_spawns_overlay`
  - `setup_pause_screen_has_two_buttons`
  - `pause_screen_has_resume_and_title_buttons`
  - `pause_screen_has_heading`
  - `pause_screen_despawns_on_exit`
  - `toggle_pause_playing_to_paused`
  - `toggle_pause_paused_to_playing`

Closes #65

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added pause screen with Resume and Go To Title menu options
  * Press Escape key to pause and resume gameplay
  * Pause screen overlay and heading colors are customizable through configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->