### PR TITLE
feat(ui): 勝利画面の完成 (#67)

### DIFF
--- a/app/ui/src/screens/victory.rs
+++ b/app/ui/src/screens/victory.rs
@@ -188,11 +188,13 @@ pub fn setup_victory_screen(
 #[cfg(test)]
 mod tests {
     use bevy::state::app::StatesPlugin;
+    use vs_core::resources::Language;
 
     use super::*;
     use crate::components::MenuButton;
-    use crate::hud::menu_button::LargeMenuButtonHud;
+    use crate::hud::menu_button::{LargeMenuButtonHud, LargeMenuButtonLabelHud};
     use crate::hud::screen_heading::ScreenHeadingHud;
+    use crate::i18n::TranslatableText;
 
     fn build_app() -> App {
         let mut app = App::new();
@@ -355,9 +357,28 @@ mod tests {
             texts.iter().any(|t| t.contains("777")),
             "kill count 777 should appear in a Text node; got: {texts:?}"
         );
+        let expected_gold = format!("{} 999", t("stat_gold_earned", Language::Japanese));
         assert!(
-            texts.iter().any(|t| t.contains("999")),
-            "gold 999 should appear in a Text node; got: {texts:?}"
+            texts.iter().any(|t| t.as_str() == expected_gold),
+            "gold stat row '{expected_gold}' should appear exactly; got: {texts:?}"
+        );
+    }
+
+    #[test]
+    fn title_button_label_has_i18n_key() {
+        let mut app = build_app();
+        app.add_systems(OnEnter(AppState::Victory), setup_victory_screen);
+        enter_victory(&mut app);
+
+        // The label spawned by spawn_large_menu_button(... Some("btn_to_title"))
+        // must carry a TranslatableText marker with the correct key.
+        let mut q = app
+            .world_mut()
+            .query_filtered::<&TranslatableText, With<LargeMenuButtonLabelHud>>();
+        let keys: Vec<&str> = q.iter(app.world()).map(|tt| tt.0).collect();
+        assert!(
+            keys.contains(&"btn_to_title"),
+            "title button label must carry TranslatableText(\"btn_to_title\"); got: {keys:?}"
         );
     }
 }


### PR DESCRIPTION
## 概要

勝利画面に獲得ゴールドの表示を追加し、ボタン配置の不具合を修正しました。

## 対応内容

- `gold_earned` を統計行に追加（クリアタイム・到達レベル・撃破数・獲得ゴールド）
- 孤立スペーサーノードを修正 — タイトルボタンを適切なコンテナの `.with_children()` 内に配置
- `btn_to_title` i18nキー対応（`Some("btn_to_title")` を渡すよう変更）
- テストに `gold_earned: 999` の確認を追加

## 機能解説

| 要素 | 詳細 |
|------|------|
| 「YOU WIN!」見出し | `VictoryScreenParams.victory_color` から読み込み |
| 統計 | clear_time / current_level / kill_count / **gold_earned** を `GameData` から表示 |
| 「タイトルへ」ボタン | `GoToTitle` → `AppState::Title` |

## 影響範囲

| クレート | モジュール/ファイル | 変更内容 |
|---------|-------------------|---------|
| `vs-ui` | `screens/victory.rs` | gold_earned 追加、ボタン配置修正 |

## テスト計画

- [x] `just fmt` — フォーマット確認
- [x] `just clippy` — 警告なし
- [x] `just test` — 全622テスト通過（stats_reflect_game_data が gold_earned を確認）

Closes #67

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Gold earned is now shown on the Victory screen as a stat.

* **UI Improvements**
  * Title button repositioned into the top container for improved layout.
  * Title button label now uses a translatable marker to ensure proper localization.

* **Tests**
  * Tests updated to assert gold display and the translatable title button label.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->