### PR TITLE
feat(core): 宝箱エンティティに黄色プレースホルダースプライトを追加

### DIFF
--- a/app/core/src/systems/xp/treasure.rs
+++ b/app/core/src/systems/xp/treasure.rs
@@ -166,7 +166,7 @@ pub fn apply_evolution(
 /// when config is not yet loaded).
 ///
 /// The chest uses a yellow square placeholder sprite (replace with pixel-art
-/// chest sprite in Phase 17).  z = 1.5 places it above enemies (z ≈ 1) so
+/// chest sprite in Phase 17).  z = 6.0 places it above enemies (z = 5.0) so
 /// it is always visible.
 ///
 /// Called by the spawner system when a treasure drop is triggered.
@@ -178,7 +178,7 @@ pub fn spawn_treasure(commands: &mut Commands, position: Vec2, radius: f32) {
             custom_size: Some(Vec2::splat(radius * 2.0)),
             ..default()
         },
-        Transform::from_xyz(position.x, position.y, 1.5),
+        Transform::from_xyz(position.x, position.y, 6.0),
         CircleCollider { radius },
         Treasure,
         GameSessionEntity,
@@ -352,7 +352,7 @@ mod tests {
         assert!(b < 0.3, "blue channel must be low for yellow sprite");
     }
 
-    /// `spawn_treasure` z-coordinate must be above enemies (z > 1).
+    /// `spawn_treasure` z-coordinate must be above enemies (z > 5.0).
     #[test]
     fn spawn_treasure_z_above_enemies() {
         use bevy::ecs::system::RunSystemOnce as _;
@@ -378,8 +378,8 @@ mod tests {
         let tf = q.single(app.world()).expect("treasure entity must exist");
 
         assert!(
-            tf.translation.z > 1.0,
-            "treasure z ({}) must be above enemies (z ≈ 1)",
+            tf.translation.z > 5.0,
+            "treasure z ({}) must be above enemies (z = 5.0)",
             tf.translation.z
         );
         assert_eq!(tf.translation.x, 10.0, "x position must match");


### PR DESCRIPTION
## 概要
Issue #73 の受け入れ基準を満たすため、`spawn_treasure` に黄色の正方形プレースホルダースプライトを追加した。
`Treasure` コンポーネントと `TreasureContent` enum はすでに存在していたため、スプライトの追加とテストが主な変更内容。

## 変更内容
- `spawn_treasure` に黄色 `Sprite`（`radius * 2` の正方形）を追加
- z座標を `1.5` に設定（敵の z ≈ 1 より上に表示）
- テスト追加: `spawn_treasure_has_yellow_sprite`（色・サイズ検証）
- テスト追加: `spawn_treasure_z_above_enemies`（z座標・位置検証）

## テスト
- [x] ユニットテスト追加（5テスト全通過）
- [x] `just fmt` / `just clippy` / `just test` / `just build` 実行済み

Closes #73

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Treasure items now display as yellow placeholder sprites and render above enemies for improved visibility.

* **Tests**
  * Added tests confirming treasure appearance, size, color, and correct positioning/z-order.

* **Documentation**
  * Expanded notes describing the yellow placeholder sprite and its rendering rationale.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->