### PR TITLE
feat(collision): プレイヤーと宝箱の接触時に TreasureOpenedEvent を送信

### DIFF
--- a/app/core/src/events.rs
+++ b/app/core/src/events.rs
@@ -116,3 +116,17 @@ pub struct LevelUpEvent {
     /// The player's new level after the level-up.
     pub new_level: u32,
 }
+
+/// Fired when the player touches a treasure chest and it is opened.
+///
+/// Emitted by
+/// [`open_treasure_chests`](crate::systems::xp::treasure::open_treasure_chests)
+/// immediately before the chest entity is despawned.
+///
+/// Consumers (audio SFX, HUD flash, etc.) use this event to react to the
+/// chest opening without querying the (now-despawned) entity.
+#[derive(Message, Debug, Clone)]
+pub struct TreasureOpenedEvent {
+    /// World-space position of the chest at the moment it was opened.
+    pub position: Vec2,
+}

--- a/app/core/src/lib.rs
+++ b/app/core/src/lib.rs
@@ -10,7 +10,7 @@ use bevy::prelude::*;
 
 use events::{
     BossSpawnedEvent, DamageEnemyEvent, EnemyDiedEvent, GameOverEvent, LevelUpEvent,
-    PlayerDamagedEvent, VictoryEvent, WeaponFiredEvent,
+    PlayerDamagedEvent, TreasureOpenedEvent, VictoryEvent, WeaponFiredEvent,
 };
 use resources::{
     EnemySpawner, GameData, GameSettings, LevelUpChoices, MetaProgress, PendingUpgradeIndex,
@@ -87,6 +87,7 @@ impl Plugin for GameCorePlugin {
             .add_message::<VictoryEvent>()
             .add_message::<LevelUpEvent>()
             .add_message::<BossSpawnedEvent>()
+            .add_message::<TreasureOpenedEvent>()
             // ---------------------------------------------------------------
             // Per-run reset: fires only when a brand-new run begins.
             // Covers both entry paths — Title → Playing (when CharacterSelect

--- a/app/core/src/systems/xp/treasure.rs
+++ b/app/core/src/systems/xp/treasure.rs
@@ -21,6 +21,7 @@ use crate::{
         CircleCollider, GameSessionEntity, PassiveInventory, Player, Treasure, WeaponInventory,
     },
     config::GameParams,
+    events::TreasureOpenedEvent,
     resources::GameData,
     types::WeaponType,
 };
@@ -57,6 +58,7 @@ const DEFAULT_MAX_WEAPON_LEVEL: u8 = 8;
 pub fn open_treasure_chests(
     mut commands: Commands,
     mut game_data: ResMut<GameData>,
+    mut opened_events: MessageWriter<TreasureOpenedEvent>,
     game_cfg: GameParams,
     player_q: Query<
         (
@@ -88,6 +90,13 @@ pub fn open_treasure_chests(
         if dist > threshold {
             continue;
         }
+
+        let chest_pos = treasure_tf.translation.truncate();
+
+        // Notify listeners (audio, HUD, etc.) before the entity is gone.
+        opened_events.write(TreasureOpenedEvent {
+            position: chest_pos,
+        });
 
         // Despawn the chest immediately.
         commands.entity(treasure_entity).despawn();
@@ -194,6 +203,7 @@ mod tests {
     use super::*;
     use crate::{
         components::{CircleCollider, PassiveInventory, WeaponInventory},
+        events::TreasureOpenedEvent,
         resources::GameData,
         states::AppState,
         types::{PassiveItemType, PassiveState, WeaponState, WeaponType},
@@ -206,6 +216,7 @@ mod tests {
         app.add_plugins((MinimalPlugins, StatesPlugin))
             .init_state::<AppState>()
             .insert_resource(GameData::default())
+            .add_message::<TreasureOpenedEvent>()
             .add_observer(apply_evolution)
             .add_systems(
                 Update,
@@ -312,6 +323,47 @@ mod tests {
             "Whip should have evolved to BloodyTear"
         );
         assert!(inv.weapons[0].evolved, "evolved flag should be set");
+    }
+
+    /// Opening a chest emits exactly one [`TreasureOpenedEvent`] at the chest
+    /// position.
+    #[test]
+    fn treasure_emits_opened_event_on_collection() {
+        let mut app = build_app();
+        spawn_player_at(&mut app, Vec2::ZERO);
+        let chest_pos = Vec2::new(5.0, 5.0); // inside overlap range
+        spawn_treasure_at(&mut app, chest_pos);
+
+        app.update();
+
+        let messages = app.world().resource::<Messages<TreasureOpenedEvent>>();
+        let events: Vec<_> = messages.get_cursor().read(messages).cloned().collect();
+        assert_eq!(
+            events.len(),
+            1,
+            "exactly one TreasureOpenedEvent should fire"
+        );
+        assert!(
+            (events[0].position - chest_pos).length() < 0.001,
+            "event position must match chest position"
+        );
+    }
+
+    /// When player is out of range, no [`TreasureOpenedEvent`] is emitted.
+    #[test]
+    fn no_event_when_treasure_out_of_range() {
+        let mut app = build_app();
+        spawn_player_at(&mut app, Vec2::ZERO);
+        spawn_treasure_at(&mut app, Vec2::new(500.0, 0.0));
+
+        app.update();
+
+        let messages = app.world().resource::<Messages<TreasureOpenedEvent>>();
+        assert_eq!(
+            messages.get_cursor().read(messages).count(),
+            0,
+            "no TreasureOpenedEvent when chest is out of range"
+        );
     }
 
     /// `spawn_treasure` must produce a yellow `Sprite` of the correct size.


### PR DESCRIPTION
## 概要
Issue #75 の実装。プレイヤーが宝箱の衝突範囲内に入ると自動開封される挙動は既に
`open_treasure_chests` に実装済みだったため、`TreasureOpenedEvent` の追加と
開封済み宝箱の削除確認が主な変更内容となった。

## 変更内容
- `TreasureOpenedEvent { position: Vec2 }` を `events.rs` に追加
- `GameCorePlugin` に `add_message::<TreasureOpenedEvent>()` を登録
- `open_treasure_chests` で宝箱を despawn する前にイベントを送信
- テスト追加: 開封時にイベントが1件送信されること / 範囲外では送信されないこと

## テスト
- [x] ユニットテスト追加（9件全通過）
- [x] `just fmt` / `just clippy` / `just test` (660件) / `just build` 実行済み

Closes #75

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced treasure chest event system that activates when chests are collected, providing precise position data to enable synchronized responses across multiple gameplay systems. This allows audio effects, visual feedback, particle animations, and HUD updates to trigger in perfect coordination, creating more immersive and cohesive treasure discovery moments throughout gameplay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->