### PR TITLE
feat(xp): MetaProgress.total_gold を宝箱ゴールド報酬時に更新 (Issue #77)

### DIFF
--- a/app/core/src/systems/xp/treasure.rs
+++ b/app/core/src/systems/xp/treasure.rs
@@ -11,6 +11,10 @@
 //!    - **HP recovery** — restores `treasure_hp_recovery_pct × max_hp`.
 //!    - **Gold** — adds `treasure_gold_reward` to [`GameData`].
 //!
+//! Gold is added to both [`GameData::gold_earned`] (run total) and
+//! [`MetaProgress::total_gold`] (persistent total) when the gold reward is
+//! chosen.
+//!
 //! At most **one chest is collected per frame** to keep inventory state
 //! consistent: `apply_evolution` runs deferred via a trigger, so collecting a
 //! second chest in the same frame would see a stale (pre-evolution) inventory.
@@ -27,7 +31,7 @@ use crate::{
     },
     config::{GameParams, PassiveConfig, PassiveParams},
     events::TreasureOpenedEvent,
-    resources::GameData,
+    resources::{GameData, MetaProgress},
     types::{UpgradeChoice, WeaponType},
 };
 
@@ -66,9 +70,11 @@ const DEFAULT_TREASURE_HP_RECOVERY_PCT: f32 = 0.3;
 /// added if chest counts ever become significant.
 ///
 /// Runs every frame while in `AppState::Playing`.
+#[allow(clippy::too_many_arguments)]
 pub fn open_treasure_chests(
     mut commands: Commands,
     mut game_data: ResMut<GameData>,
+    mut meta_progress: ResMut<MetaProgress>,
     mut opened_events: MessageWriter<TreasureOpenedEvent>,
     game_cfg: GameParams,
     passive_cfg: PassiveParams,
@@ -129,7 +135,7 @@ pub fn open_treasure_chests(
                 evolved_type: evolved,
             });
         } else {
-            apply_non_evolution_reward(
+            let reward = apply_non_evolution_reward(
                 &mut weapon_inv,
                 &mut passive_inv,
                 &mut stats,
@@ -142,6 +148,10 @@ pub fn open_treasure_chests(
                 max_weapon_level,
                 max_passive_level,
             );
+            // Gold is also counted toward the persistent cross-run total.
+            if matches!(reward, Reward::Gold) {
+                meta_progress.total_gold += gold_reward;
+            }
         }
 
         // Process at most one chest per frame to avoid stale-inventory decisions.
@@ -246,6 +256,9 @@ pub(crate) fn apply_reward(
 }
 
 /// Picks and applies a random non-evolution reward.
+///
+/// Returns the [`Reward`] that was chosen so the caller can perform
+/// any additional bookkeeping (e.g. updating [`MetaProgress`]).
 fn apply_non_evolution_reward(
     weapon_inv: &mut WeaponInventory,
     passive_inv: &mut PassiveInventory,
@@ -254,9 +267,10 @@ fn apply_non_evolution_reward(
     ctx: &RewardContext<'_>,
     max_weapon_level: u8,
     max_passive_level: u8,
-) {
+) -> Reward {
     let reward = pick_reward(weapon_inv, passive_inv, max_weapon_level, max_passive_level);
     apply_reward(reward, weapon_inv, passive_inv, stats, game_data, ctx);
+    reward
 }
 
 /// Observer trigger fired when a treasure chest evolution is detected.
@@ -345,7 +359,7 @@ mod tests {
     use crate::{
         components::{CircleCollider, PassiveInventory, PlayerStats, WeaponInventory},
         events::TreasureOpenedEvent,
-        resources::GameData,
+        resources::{GameData, MetaProgress},
         states::AppState,
         types::{PassiveItemType, PassiveState, UpgradeChoice, WeaponState, WeaponType},
     };
@@ -356,6 +370,7 @@ mod tests {
         app.add_plugins((MinimalPlugins, StatesPlugin))
             .init_state::<AppState>()
             .insert_resource(GameData::default())
+            .insert_resource(MetaProgress::default())
             .add_message::<TreasureOpenedEvent>()
             .add_observer(apply_evolution)
             .add_systems(
@@ -437,6 +452,75 @@ mod tests {
         );
         // Gold or HP was the outcome. At least the system ran without panicking.
         let _ = gold;
+    }
+
+    /// When gold is the reward, `MetaProgress::total_gold` is also updated.
+    ///
+    /// This verifies that the persistent cross-run total is incremented along
+    /// with the run-local `GameData::gold_earned`.
+    #[test]
+    fn gold_reward_updates_meta_progress_total_gold() {
+        let mut app = build_app();
+
+        // Player with full HP, no weapons/passives → upgrade pool is empty.
+        // Only gold or HP recovery can be chosen; run until gold is awarded.
+        spawn_player_at(&mut app, Vec2::ZERO);
+        for _ in 0..100 {
+            spawn_treasure_at(&mut app, Vec2::ZERO);
+            app.update();
+
+            let gold = app.world().resource::<GameData>().gold_earned;
+            let total = app.world().resource::<MetaProgress>().total_gold;
+
+            if gold > 0 {
+                // When gold was awarded, both fields must be equal.
+                assert_eq!(
+                    total, gold,
+                    "MetaProgress::total_gold must equal GameData::gold_earned when gold is the reward"
+                );
+                return;
+            }
+        }
+        // Reaching here without gold in 100 chest openings is astronomically unlikely.
+        panic!("gold reward never triggered in 100 chest openings");
+    }
+
+    /// When evolution is triggered (not gold), `MetaProgress::total_gold` stays zero.
+    #[test]
+    fn evolution_reward_does_not_update_total_gold() {
+        let mut app = build_app();
+
+        let mut whip = WeaponState::new(WeaponType::Whip);
+        whip.level = 8;
+        let passive = PassiveInventory {
+            items: vec![PassiveState {
+                item_type: PassiveItemType::HollowHeart,
+                level: 1,
+            }],
+        };
+        let mut stats = PlayerStats::default();
+        stats.max_hp = 100.0;
+        stats.current_hp = 100.0;
+        app.world_mut().spawn((
+            Player,
+            WeaponInventory {
+                weapons: vec![whip],
+            },
+            passive,
+            stats,
+            Transform::from_xyz(0.0, 0.0, 0.0),
+            CircleCollider {
+                radius: DEFAULT_TREASURE_RADIUS,
+            },
+        ));
+        spawn_treasure_at(&mut app, Vec2::ZERO);
+        app.update();
+
+        let total = app.world().resource::<MetaProgress>().total_gold;
+        assert_eq!(
+            total, 0,
+            "MetaProgress::total_gold must not change on evolution reward"
+        );
     }
 
     /// When an evolvable weapon is present, the evolution triggers and no gold


### PR DESCRIPTION
## 概要

宝箱を開けてゴールド報酬が選ばれた際、`GameData.gold_earned`（ラン内合計）に加えて `MetaProgress.total_gold`（永続化合計）も更新するようにした。これにより Issue #77 の受け入れ基準をすべて満たす。

## 変更内容

- `apply_non_evolution_reward` が選択した `Reward` を返すよう変更（呼び出し側が後処理を行えるように）
- `open_treasure_chests` で返り値を検査し、`Reward::Gold` の場合に `MetaProgress.total_gold += gold_reward` を実行
- システムパラメータに `ResMut<MetaProgress>` を追加（`#[allow(clippy::too_many_arguments)]` で lint 抑制）
- テストの `build_app()` に `MetaProgress::default()` リソースを追加

## テスト

- [x] `gold_reward_updates_meta_progress_total_gold` — ゴールド報酬時に `total_gold` が更新されること
- [x] `evolution_reward_does_not_update_total_gold` — 進化報酬時は `total_gold` が変化しないこと
- [x] 全テスト 496件 パス
- [x] `just clippy` — 警告ゼロ

Closes #77

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Persistent gold tracking now accurately records cumulative gold earned throughout gameplay.

* **Improvements**
  * Enhanced reward system to properly maintain and update gold statistics.

* **Tests**
  * Extended test coverage to verify gold reward tracking and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->