### PR TITLE
refactor(core): DEFAULT_ENEMY_SPAWN_BASE_INTERVAL を config/enemy.rs に統合 (Issue #219)

### DIFF
--- a/app/core/src/config/enemy.rs
+++ b/app/core/src/config/enemy.rs
@@ -7,6 +7,16 @@ use serde::Deserialize;
 use crate::types::EnemyType;
 
 // ---------------------------------------------------------------------------
+// Fallback constants (used while enemy.ron is still loading)
+// ---------------------------------------------------------------------------
+
+/// Base enemy spawn interval in seconds when difficulty multiplier is 1.0.
+///
+/// Single source of truth — import this instead of redefining the constant
+/// in each system file.
+pub(crate) const DEFAULT_ENEMY_SPAWN_BASE_INTERVAL: f32 = 0.5;
+
+// ---------------------------------------------------------------------------
 // Medusa AI behavior config
 // ---------------------------------------------------------------------------
 
@@ -158,6 +168,13 @@ impl<'w> EnemyParams<'w> {
         self.handle
             .as_ref()
             .and_then(|h| self.assets.as_ref().and_then(|a| a.get(&h.0)))
+    }
+
+    /// Returns the base spawn interval, falling back to [`DEFAULT_ENEMY_SPAWN_BASE_INTERVAL`].
+    pub fn spawn_base_interval(&self) -> f32 {
+        self.get()
+            .map(|c| c.spawn_base_interval)
+            .unwrap_or(DEFAULT_ENEMY_SPAWN_BASE_INTERVAL)
     }
 }
 

--- a/app/core/src/resources/spawner.rs
+++ b/app/core/src/resources/spawner.rs
@@ -1,11 +1,6 @@
 use bevy::prelude::*;
 
-// ---------------------------------------------------------------------------
-// Fallback constants (used when RON config is not yet loaded)
-// ---------------------------------------------------------------------------
-
-/// Base enemy spawn interval in seconds.
-const DEFAULT_ENEMY_SPAWN_BASE_INTERVAL: f32 = 0.5;
+use crate::config::enemy::DEFAULT_ENEMY_SPAWN_BASE_INTERVAL;
 
 /// Controls enemy spawn timing and difficulty scaling.
 #[derive(Resource, Debug)]

--- a/app/core/src/systems/enemies/difficulty.rs
+++ b/app/core/src/systems/enemies/difficulty.rs
@@ -22,7 +22,7 @@
 use bevy::prelude::*;
 
 use crate::{
-    config::EnemyParams,
+    config::{EnemyParams, enemy::DEFAULT_ENEMY_SPAWN_BASE_INTERVAL},
     resources::{EnemySpawner, GameData},
 };
 
@@ -30,8 +30,6 @@ use crate::{
 // Fallback constants (used when RON config is not yet loaded)
 // ---------------------------------------------------------------------------
 
-/// Base enemy spawn interval in seconds.
-const DEFAULT_ENEMY_SPAWN_BASE_INTERVAL: f32 = 0.5;
 /// Hard cap for the difficulty multiplier.
 const DEFAULT_DIFFICULTY_MAX: f32 = 10.0;
 
@@ -78,10 +76,7 @@ pub fn update_difficulty(
     mut spawner: ResMut<EnemySpawner>,
     enemy_cfg: EnemyParams,
 ) {
-    let base_interval = enemy_cfg
-        .get()
-        .map(|c| c.spawn_base_interval)
-        .unwrap_or(DEFAULT_ENEMY_SPAWN_BASE_INTERVAL);
+    let base_interval = enemy_cfg.spawn_base_interval();
     let diff_max = enemy_cfg
         .get()
         .map(|c| c.difficulty_max)

--- a/app/core/src/systems/enemies/spawn.rs
+++ b/app/core/src/systems/enemies/spawn.rs
@@ -88,10 +88,6 @@ const DEFAULT_WINDOW_WIDTH: u32 = 1280;
 const DEFAULT_WINDOW_HEIGHT: u32 = 720;
 /// Extra pixels beyond the half-viewport edge at which enemies appear.
 const DEFAULT_SPAWN_MARGIN: f32 = 60.0;
-/// Base enemy spawn interval in seconds (mirrors EnemyConfig default).
-/// Only used in tests to set `spawn_timer` past the threshold.
-#[cfg(test)]
-const DEFAULT_ENEMY_SPAWN_BASE_INTERVAL: f32 = 0.5;
 
 // ---------------------------------------------------------------------------
 // System
@@ -420,6 +416,7 @@ mod tests {
     use bevy::state::app::StatesPlugin;
 
     use super::*;
+    use crate::config::enemy::DEFAULT_ENEMY_SPAWN_BASE_INTERVAL;
     use crate::resources::GameData;
     use crate::states::AppState;
 


### PR DESCRIPTION
## 概要

Issue #219 の対応として、3ファイルに重複していた `DEFAULT_ENEMY_SPAWN_BASE_INTERVAL` を `config/enemy.rs` に一元化しました。

## 変更内容

### `config/enemy.rs`
- `pub(crate) const DEFAULT_ENEMY_SPAWN_BASE_INTERVAL: f32 = 0.5;` を追加（唯一の定義）
- `EnemyParams::spawn_base_interval()` 便利メソッドを追加

### 削除したローカル定数
| ファイル | 変更 |
|---|---|
| `resources/spawner.rs` | ローカル `const` を削除 → `use crate::config::enemy::DEFAULT_ENEMY_SPAWN_BASE_INTERVAL` に置換 |
| `systems/enemies/difficulty.rs` | ローカル `const` を削除 → `EnemyParams::spawn_base_interval()` 呼び出しに統一 |
| `systems/enemies/spawn.rs` | `#[cfg(test)]` のローカル `const` を削除 → テストモジュールで `use crate::config::enemy::DEFAULT_ENEMY_SPAWN_BASE_INTERVAL` |

## テスト

- `just build` ✅
- `just clippy` ✅
- `just test` ✅ (520 + 181 tests passed)

Closes #219

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized enemy spawn interval configuration by consolidating duplicate spawn interval constants from multiple modules into a single, unified definition. Added a new configuration accessor method to provide consistent access to spawn interval values throughout the enemy spawning and difficulty systems, reducing code duplication and improving overall code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->