### PR TITLE
refactor(core): DEFAULT_XP_LEVEL_BASE/MULTIPLIER を config/game.rs に統合 (Issue #220)

### DIFF
--- a/app/core/src/config/game.rs
+++ b/app/core/src/config/game.rs
@@ -22,6 +22,7 @@ pub(crate) const DEFAULT_MAX_PASSIVES: usize = 6;
 
 // --- XP / levelling ---
 pub(crate) const DEFAULT_XP_LEVEL_BASE: u32 = 20;
+pub(crate) const DEFAULT_XP_LEVEL_MULTIPLIER: f32 = 1.2;
 pub(crate) const DEFAULT_CHOICE_COUNT: usize = 3;
 pub(crate) const DEFAULT_LUCK_BONUS_CHOICE_THRESHOLD: f32 = 1.5;
 
@@ -276,6 +277,12 @@ impl<'w> GameParams<'w> {
         self.get()
             .map(|c| c.xp_level_base)
             .unwrap_or(DEFAULT_XP_LEVEL_BASE)
+    }
+
+    pub fn xp_level_multiplier(&self) -> f32 {
+        self.get()
+            .map(|c| c.xp_level_multiplier)
+            .unwrap_or(DEFAULT_XP_LEVEL_MULTIPLIER)
     }
 
     pub fn choice_count(&self) -> usize {

--- a/app/core/src/systems/xp/level_up.rs
+++ b/app/core/src/systems/xp/level_up.rs
@@ -17,20 +17,6 @@ use bevy::prelude::*;
 use crate::{config::GameParams, events::LevelUpEvent, resources::GameData, states::AppState};
 
 // ---------------------------------------------------------------------------
-// Fallback constants
-// ---------------------------------------------------------------------------
-
-/// XP required for the very first level-up.
-///
-/// Used when the RON game config has not yet loaded.
-const DEFAULT_XP_LEVEL_BASE: u32 = 20;
-
-/// Exponential multiplier applied to the XP threshold on each level-up.
-///
-/// Used when the RON game config has not yet loaded.
-const DEFAULT_XP_LEVEL_MULTIPLIER: f32 = 1.2;
-
-// ---------------------------------------------------------------------------
 // System
 // ---------------------------------------------------------------------------
 
@@ -55,14 +41,8 @@ pub fn check_level_up(
     game_data.current_level += 1;
 
     // Recompute the threshold for the next level using the exponential curve.
-    let base = game_cfg
-        .get()
-        .map(|c| c.xp_level_base)
-        .unwrap_or(DEFAULT_XP_LEVEL_BASE);
-    let mult = game_cfg
-        .get()
-        .map(|c| c.xp_level_multiplier)
-        .unwrap_or(DEFAULT_XP_LEVEL_MULTIPLIER);
+    let base = game_cfg.xp_level_base();
+    let mult = game_cfg.xp_level_multiplier();
     game_data.xp_to_next_level =
         (base as f32 * mult.powi(game_data.current_level as i32 - 1)).round() as u32;
 


### PR DESCRIPTION
## 概要

Issue #220 の対応として、`systems/xp/level_up.rs` に残っていたローカル定数を `config/game.rs` に統合しました。

## 変更内容

### `config/game.rs`
- `pub(crate) const DEFAULT_XP_LEVEL_MULTIPLIER: f32 = 1.2;` を追加
- `GameParams::xp_level_multiplier()` 便利メソッドを追加
  （`DEFAULT_XP_LEVEL_BASE` / `GameParams::xp_level_base()` は #214 で対応済み）

### `systems/xp/level_up.rs`
- `DEFAULT_XP_LEVEL_BASE`・`DEFAULT_XP_LEVEL_MULTIPLIER` のローカル定数を削除
- `game_cfg.get().map(...).unwrap_or(...)` を `game_cfg.xp_level_base()` / `game_cfg.xp_level_multiplier()` に統一

## テスト

- `just build` ✅
- `just clippy` ✅
- `just test` ✅ (520 + 181 tests passed)

Closes #220

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved XP progression system configuration with enhanced default value handling and streamlined config access methods for more reliable experience progression behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->