### PR TITLE
fix(core): persistence.rs のテストモジュール後の本番コードを移動 (Issue #221)

### DIFF
--- a/app/core/src/systems/persistence.rs
+++ b/app/core/src/systems/persistence.rs
@@ -89,6 +89,17 @@ pub fn save_meta_on_shop_exit(meta: Res<MetaProgress>) {
 }
 
 // ---------------------------------------------------------------------------
+// GameSettings auto-save
+// ---------------------------------------------------------------------------
+
+/// Saves [`GameSettings`] to `save/settings.json` when the player exits the
+/// [`crate::states::AppState::Settings`] screen.
+pub fn save_settings_on_exit(settings: Res<GameSettings>) {
+    info!("Saving settings (settings screen exit)…");
+    settings.save();
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -170,15 +181,4 @@ mod tests {
         let meta = app.world().resource::<MetaProgress>();
         assert_eq!(meta.total_gold, u32::MAX, "should saturate at u32::MAX");
     }
-}
-
-// ---------------------------------------------------------------------------
-// GameSettings auto-save
-// ---------------------------------------------------------------------------
-
-/// Saves [`GameSettings`] to `save/settings.json` when the player exits the
-/// [`crate::states::AppState::Settings`] screen.
-pub fn save_settings_on_exit(settings: Res<GameSettings>) {
-    info!("Saving settings (settings screen exit)…");
-    settings.save();
 }


### PR DESCRIPTION
## 概要

Issue #221 の対応として、`save_settings_on_exit` 関数をテストモジュールの**前**に移動しました。

## 変更内容

`systems/persistence.rs` のファイル構成を Rust 慣習に合わせて修正：

**変更前**
```
型定義 → MetaProgress 保存関数 → #[cfg(test)] → GameSettings 保存関数
```

**変更後**
```
型定義 → MetaProgress 保存関数 → GameSettings 保存関数 → #[cfg(test)]
```

コードの追加・削除はなく、セクションの順序変更のみです。

## テスト

- `just build` ✅
- `just clippy` ✅
- `just test` ✅ (520 + 181 tests passed)

Closes #221

🤖 Generated with [Claude Code](https://claude.com/claude-code)