### PR TITLE
fix(ui): upgrade_card.rs の非推奨 iter_entities() を query::<Entity>() に置換 (Issue #222)

### DIFF
--- a/app/ui/src/hud/upgrade_card.rs
+++ b/app/ui/src/hud/upgrade_card.rs
@@ -630,7 +630,11 @@ mod tests {
             );
 
             // Clean up spawned entities before the next iteration.
-            let entities: Vec<Entity> = app.world_mut().iter_entities().map(|e| e.id()).collect();
+            let entities: Vec<Entity> = app
+                .world_mut()
+                .query::<Entity>()
+                .iter(app.world())
+                .collect();
             for e in entities {
                 app.world_mut().despawn(e);
             }


### PR DESCRIPTION
## 概要

Issue #222 の対応として、テストコード内の非推奨 `iter_entities()` を Bevy 0.17 の正式 API に置き換えました。

## 変更内容

`app/ui/src/hud/upgrade_card.rs` テストの cleanup コード：

**変更前**
```rust
let entities: Vec<Entity> = app.world_mut().iter_entities().map(|e| e.id()).collect();
```

**変更後**
```rust
let entities: Vec<Entity> = app.world_mut().query::<Entity>().iter(app.world()).collect();
```

`World::iter_entities()` は Bevy 0.17 で deprecated。`world.query::<Entity>().iter(world)` が慣用的な代替です。

## テスト

- `just build` ✅
- `just clippy` ✅ (警告なし)
- `just test` ✅ (520 + 181 tests passed)

Closes #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test cleanup infrastructure to enhance testing efficiency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->