### PR TITLE
refactor(core): DEFAULT_SPATIAL_GRID_CELL_SIZE を config/game.rs に統合 (Issue #223)

### DIFF
--- a/app/core/src/config/game.rs
+++ b/app/core/src/config/game.rs
@@ -26,6 +26,9 @@ pub(crate) const DEFAULT_XP_LEVEL_MULTIPLIER: f32 = 1.2;
 pub(crate) const DEFAULT_CHOICE_COUNT: usize = 3;
 pub(crate) const DEFAULT_LUCK_BONUS_CHOICE_THRESHOLD: f32 = 1.5;
 
+// --- spatial grid ---
+pub(crate) const DEFAULT_SPATIAL_GRID_CELL_SIZE: f32 = 64.0;
+
 // --- treasure chests ---
 pub(crate) const DEFAULT_TREASURE_RADIUS: f32 = 20.0;
 pub(crate) const DEFAULT_TREASURE_GOLD: u32 = 50;
@@ -327,6 +330,12 @@ impl<'w> GameParams<'w> {
         self.get()
             .map(|c| c.treasure_spawn_flash_duration)
             .unwrap_or(DEFAULT_TREASURE_SPAWN_FLASH_DURATION)
+    }
+
+    pub fn spatial_grid_cell_size(&self) -> f32 {
+        self.get()
+            .map(|c| c.spatial_grid_cell_size)
+            .unwrap_or(DEFAULT_SPATIAL_GRID_CELL_SIZE)
     }
 }
 

--- a/app/core/src/resources/spatial.rs
+++ b/app/core/src/resources/spatial.rs
@@ -2,12 +2,7 @@ use std::collections::HashMap;
 
 use bevy::prelude::*;
 
-// ---------------------------------------------------------------------------
-// Fallback constants (used when RON config is not yet loaded)
-// ---------------------------------------------------------------------------
-
-/// Grid cell size for spatial partitioning (pixels).
-const DEFAULT_SPATIAL_GRID_CELL_SIZE: f32 = 64.0;
+use crate::config::game::DEFAULT_SPATIAL_GRID_CELL_SIZE;
 
 /// Grid-based spatial partitioning used to accelerate collision detection.
 ///


### PR DESCRIPTION
## 概要

Issue #223 の対応として、`resources/spatial.rs` のローカル定数を `config/game.rs` に統合しました。

## 変更内容

### `config/game.rs`
- `pub(crate) const DEFAULT_SPATIAL_GRID_CELL_SIZE: f32 = 64.0;` を追加
- `GameParams::spatial_grid_cell_size()` 便利メソッドを追加

### `resources/spatial.rs`
- ローカル `const DEFAULT_SPATIAL_GRID_CELL_SIZE` を削除
- `use crate::config::game::DEFAULT_SPATIAL_GRID_CELL_SIZE;` を追加
- `SpatialGrid::default()` は変更なし（同名の定数を継続使用）

`systems/spatial.rs` は定数を直接参照していないため変更不要。

## テスト

- `just build` ✅
- `just clippy` ✅
- `just test` ✅ (520 + 181 tests passed)

Closes #223

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Centralized spatial grid configuration management for improved consistency across the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->