### PR TITLE
feat(xp): 敵の強さに応じた段階的XPジェムドロップを実装

### DIFF
--- a/app/core/src/components/collectible.rs
+++ b/app/core/src/components/collectible.rs
@@ -1,9 +1,12 @@
 use bevy::prelude::*;
 
+use crate::types::GemTier;
+
 /// An XP gem dropped by a defeated enemy.
 #[derive(Component, Debug)]
 pub struct ExperienceGem {
     pub value: u32,
+    pub tier: GemTier,
 }
 
 /// A gold coin dropped by a defeated enemy.

--- a/app/core/src/systems/xp/attraction.rs
+++ b/app/core/src/systems/xp/attraction.rs
@@ -124,6 +124,7 @@ mod tests {
     use crate::{
         components::{AttractedToPlayer, ExperienceGem, Player, PlayerStats},
         resources::GameData,
+        types::GemTier,
     };
 
     fn build_app() -> App {
@@ -146,7 +147,10 @@ mod tests {
     fn spawn_gem(app: &mut App, pos: Vec2, value: u32) -> Entity {
         app.world_mut()
             .spawn((
-                ExperienceGem { value },
+                ExperienceGem {
+                    value,
+                    tier: GemTier::from_value(value),
+                },
                 Transform::from_xyz(pos.x, pos.y, 0.5),
             ))
             .id()
@@ -197,7 +201,10 @@ mod tests {
         let gem = app
             .world_mut()
             .spawn((
-                ExperienceGem { value: 3 },
+                ExperienceGem {
+                    value: 3,
+                    tier: GemTier::from_value(3),
+                },
                 Transform::from_xyz(10.0, 0.0, 0.5),
                 AttractedToPlayer { speed: 999.0 }, // sentinel speed
             ))
@@ -239,7 +246,10 @@ mod tests {
         let gem = app
             .world_mut()
             .spawn((
-                ExperienceGem { value: 3 },
+                ExperienceGem {
+                    value: 3,
+                    tier: GemTier::from_value(3),
+                },
                 Transform::from_xyz(100.0, 0.0, 0.5),
                 AttractedToPlayer {
                     speed: PlayerStats::default().gem_attraction_speed,
@@ -273,7 +283,10 @@ mod tests {
         spawn_player(&mut app, Vec2::ZERO);
         // Place gem very close to player (within ABSORPTION_RADIUS).
         app.world_mut().spawn((
-            ExperienceGem { value: 5 },
+            ExperienceGem {
+                value: 5,
+                tier: GemTier::from_value(5),
+            },
             Transform::from_xyz(2.0, 0.0, 0.5), // distance 2.0 < gem_absorption_radius (8.0)
             AttractedToPlayer {
                 speed: PlayerStats::default().gem_attraction_speed,
@@ -301,7 +314,10 @@ mod tests {
         spawn_player(&mut app, Vec2::ZERO);
         for value in [3, 5, 8] {
             app.world_mut().spawn((
-                ExperienceGem { value },
+                ExperienceGem {
+                    value,
+                    tier: GemTier::from_value(value),
+                },
                 Transform::from_xyz(1.0, 0.0, 0.5),
                 AttractedToPlayer {
                     speed: PlayerStats::default().gem_attraction_speed,
@@ -337,7 +353,10 @@ mod tests {
 
         for _ in 0..4 {
             app.world_mut().spawn((
-                ExperienceGem { value: 3 },
+                ExperienceGem {
+                    value: 3,
+                    tier: GemTier::from_value(3),
+                },
                 Transform::from_xyz(1.0, 0.0, 0.5),
                 AttractedToPlayer {
                     speed: PlayerStats::default().gem_attraction_speed,
@@ -368,7 +387,10 @@ mod tests {
     fn move_no_player_no_panic() {
         let mut app = build_app();
         app.world_mut().spawn((
-            ExperienceGem { value: 3 },
+            ExperienceGem {
+                value: 3,
+                tier: GemTier::from_value(3),
+            },
             Transform::from_xyz(1.0, 0.0, 0.5),
             AttractedToPlayer {
                 speed: PlayerStats::default().gem_attraction_speed,

--- a/app/core/src/systems/xp/drop.rs
+++ b/app/core/src/systems/xp/drop.rs
@@ -19,11 +19,8 @@ use crate::{
     config::GameParams,
     events::EnemyDiedEvent,
     systems::xp::treasure::spawn_treasure,
-    types::EnemyType,
+    types::{EnemyType, GemTier},
 };
-
-/// Gem visual radius in pixels (placeholder; replace with real sprite later).
-const GEM_RADIUS: f32 = 6.0;
 
 // ---------------------------------------------------------------------------
 // System
@@ -42,15 +39,17 @@ const GEM_RADIUS: f32 = 6.0;
 /// reads them.
 pub fn spawn_xp_gems(mut commands: Commands, mut died_events: MessageReader<EnemyDiedEvent>) {
     for event in died_events.read() {
+        let tier = GemTier::from_value(event.xp_value);
         commands.spawn((
             GameSessionEntity,
             ExperienceGem {
                 value: event.xp_value,
+                tier,
             },
-            // Green circle placeholder sprite; replace with real art in Phase 17.
+            // Tiered color/size placeholder sprite; replace with real art in Phase 17.
             Sprite {
-                color: Color::srgb(0.2, 0.9, 0.2),
-                custom_size: Some(Vec2::splat(GEM_RADIUS * 2.0)),
+                color: tier.color(),
+                custom_size: Some(Vec2::splat(tier.radius() * 2.0)),
                 ..default()
             },
             // z = 0.5 — above ground (z = 0) but below enemies (z ≈ 1).
@@ -116,7 +115,15 @@ mod tests {
     fn gems(app: &mut App) -> Vec<(ExperienceGem, Transform)> {
         let mut q = app.world_mut().query::<(&ExperienceGem, &Transform)>();
         q.iter(app.world())
-            .map(|(g, t)| (ExperienceGem { value: g.value }, *t))
+            .map(|(g, t)| {
+                (
+                    ExperienceGem {
+                        value: g.value,
+                        tier: g.tier,
+                    },
+                    *t,
+                )
+            })
             .collect()
     }
 

--- a/app/core/src/types/gem_tier.rs
+++ b/app/core/src/types/gem_tier.rs
@@ -1,0 +1,62 @@
+use bevy::prelude::Color;
+
+/// Visual tier of an XP gem, derived from its XP value at spawn time.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum GemTier {
+    #[default]
+    Small, // value 1–4
+    Medium, // value 5–24
+    Large,  // value 25–99
+    Boss,   // value 100+
+}
+
+impl GemTier {
+    pub fn from_value(v: u32) -> Self {
+        match v {
+            0..=4 => Self::Small,
+            5..=24 => Self::Medium,
+            25..=99 => Self::Large,
+            _ => Self::Boss,
+        }
+    }
+
+    pub fn color(self) -> Color {
+        match self {
+            Self::Small => Color::srgb(0.3, 0.5, 1.0),
+            Self::Medium => Color::srgb(0.2, 0.9, 0.3),
+            Self::Large => Color::srgb(1.0, 0.3, 0.2),
+            Self::Boss => Color::srgb(1.0, 0.9, 0.1),
+        }
+    }
+
+    pub fn radius(self) -> f32 {
+        match self {
+            Self::Small => 4.0,
+            Self::Medium => 6.0,
+            Self::Large => 9.0,
+            Self::Boss => 13.0,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_value_boundaries() {
+        assert_eq!(GemTier::from_value(0), GemTier::Small);
+        assert_eq!(GemTier::from_value(4), GemTier::Small);
+        assert_eq!(GemTier::from_value(5), GemTier::Medium);
+        assert_eq!(GemTier::from_value(24), GemTier::Medium);
+        assert_eq!(GemTier::from_value(25), GemTier::Large);
+        assert_eq!(GemTier::from_value(99), GemTier::Large);
+        assert_eq!(GemTier::from_value(100), GemTier::Boss);
+        assert_eq!(GemTier::from_value(999), GemTier::Boss);
+    }
+
+    #[test]
+    fn default_is_small() {
+        assert_eq!(GemTier::default(), GemTier::Small);
+    }
+}

--- a/app/core/src/types/mod.rs
+++ b/app/core/src/types/mod.rs
@@ -1,11 +1,13 @@
 pub mod character;
 pub mod enemy;
 pub mod game;
+pub mod gem_tier;
 pub mod stage;
 pub mod weapon;
 
 pub use character::*;
 pub use enemy::*;
 pub use game::*;
+pub use gem_tier::GemTier;
 pub use stage::StageType;
 pub use weapon::*;


### PR DESCRIPTION
## 概要

本家 Vampire Survivors のように、敵の XP 値に応じて色とサイズが異なるジェムをドロップするようにした。
これにより、プレイヤーが一目でジェムの価値を判別できるようになる。

## 変更内容

- `GemTier` enum を新規追加（Small/Medium/Large/Boss）
- `GemTier::from_value(xp_value)` でティアを決定（しきい値: 5, 25, 100）
- 各ティアに専用の色（青/緑/赤/黄）とサイズ（r=4/6/9/13）を設定
- `ExperienceGem` に `tier: GemTier` フィールドを追加
- `spawn_xp_gems` でティアに応じた色・サイズを適用

## テスト

- [x] `GemTier::from_value` の境界値ユニットテスト追加
- [x] `just clippy` 通過
- [x] `just test` 通過（529 + 187 テスト）
- [x] ゲーム内でジェム色の差異を目視確認

Closes #240

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Experience gems now feature a tiered visual system with four levels (Small, Medium, Large, Boss) that automatically scale based on XP value. Each tier displays with distinct colors and sizes for enhanced visual differentiation during gameplay and collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->